### PR TITLE
feat: Add docker attach command to cheat sheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,6 +80,11 @@
                     <p>コンテナ内に入る</p>
                 </div>
                 <div class="command-card">
+                    <h3>コンテナにアタッチ</h3>
+                    <code>docker attach [コンテナID]</code>
+                    <p>実行中のコンテナに接続。デタッチは Ctrl+P, Ctrl+Q</p>
+                </div>
+                <div class="command-card">
                     <h3>Docker Compose起動</h3>
                     <code>docker-compose up</code>
                     <p>複数コンテナを一括起動</p>


### PR DESCRIPTION
Adds the `docker attach` command to the Docker section of the command cheat sheet (`index.html`). Includes a helpful tip on how to detach from the container.