### PR TITLE
Gitコマンドページに頻出コマンドを追記

### DIFF
--- a/index.html
+++ b/index.html
@@ -342,6 +342,36 @@
                     <code>git stash</code>
                     <p>変更を一時保存</p>
                 </div>
+                <div class="command-card">
+                    <h3>フェッチ</h3>
+                    <code>git fetch</code>
+                    <p>リモートから最新情報を取得（マージなし）</p>
+                </div>
+                <div class="command-card">
+                    <h3>ブランチ切替</h3>
+                    <code>git checkout [ブランチ名]</code>
+                    <p>既存のブランチに切り替え</p>
+                </div>
+                <div class="command-card">
+                    <h3>リベース</h3>
+                    <code>git rebase [ブランチ名]</code>
+                    <p>ブランチをリベース</p>
+                </div>
+                <div class="command-card">
+                    <h3>リモートリポジトリ確認</h3>
+                    <code>git remote -v</code>
+                    <p>リモートリポジトリの一覧表示</p>
+                </div>
+                <div class="command-card">
+                    <h3>スタッシュの適用</h3>
+                    <code>git stash pop</code>
+                    <p>一時保存した変更を復元</p>
+                </div>
+                <div class="command-card">
+                    <h3>ログ詳細表示</h3>
+                    <code>git log</code>
+                    <p>コミット履歴を詳細表示</p>
+                </div>
             </div>
         </section>
 


### PR DESCRIPTION
gitのページを点検し、頻出のコマンドで抜けがあったため追記しました。
追加したコマンドは以下の通りです。

- git fetch
- git checkout [ブランチ名]
- git rebase
- git remote -v
- git stash pop
- git log