### PR TITLE
Feat: Create Hybrid Tutorial and Reference Cheat Sheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,78 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>開発コマンド チートシート</title>
     <link rel="stylesheet" href="styles.css">
-    <style>
-        /* Add new styles for the workflow guide */
-        .workflow-card {
-            background: rgba(255, 255, 255, 0.9);
-            padding: 25px;
-            border-radius: 15px;
-            box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
-            margin-bottom: 25px;
-        }
-        .workflow-card h3 {
-            color: #764ba2;
-            font-size: 20px;
-            margin-top: 20px;
-            margin-bottom: 15px;
-            padding-bottom: 5px;
-            border-bottom: 2px solid #e0e0e0;
-        }
-        .workflow-card h4 {
-            color: #5a3785;
-            font-size: 16px;
-            margin-top: 15px;
-            margin-bottom: 10px;
-        }
-        .workflow-card p, .workflow-card li {
-            color: #333;
-            font-size: 14px;
-            line-height: 1.7;
-        }
-        .workflow-card code {
-            display: block;
-            background: #f5f5f5;
-            padding: 12px;
-            border-radius: 8px;
-            font-family: 'Courier New', monospace;
-            font-size: 14px;
-            color: #d63384;
-            margin: 10px 0;
-            border-left: 4px solid #764ba2;
-            word-break: break-all;
-        }
-        .workflow-card ul {
-            padding-left: 20px;
-            margin-top: 10px;
-        }
-        .workflow-card hr {
-            border: 0;
-            height: 1px;
-            background-color: #e0e0e0;
-            margin: 25px 0;
-        }
-        .terminal-split {
-            display: flex;
-            gap: 20px;
-            margin-top: 15px;
-        }
-        .terminal {
-            flex: 1;
-            border: 1px solid #ddd;
-            border-radius: 8px;
-            padding: 15px;
-            background: #fafafa;
-        }
-        .terminal h4 {
-            margin-top: 0;
-            font-size: 15px;
-        }
-        @media (max-width: 768px) {
-            .terminal-split {
-                flex-direction: column;
-            }
-        }
-    </style>
 </head>
 <body>
     <header>
@@ -88,1856 +16,652 @@
 
     <nav class="sidebar">
         <ul class="menu">
-            <li><a href="#setup" data-category="setup">🚀 環境セットアップ</a></li>
-            <li><a href="#workflow" data-category="workflow">🌱 日常の開発フロー</a></li>
-            <li><a href="#db" data-category="db">🗄️ データベース操作</a></li>
-            <li><a href="#testing" data-category="testing">✅ テストと品質管理</a></li>
-            <li><a href="#debugging" data-category="debugging">🐛 デバッグと問題解決</a></li>
-            <li><a href="#advanced" data-category="advanced">🔧 高度なトピック</a></li>
+            <li><a href="#tutorial-setup" data-category="tutorial-setup">🚀 環境構築チュートリアル</a></li>
+            <li><a href="#tutorial-feature" data-category="tutorial-feature">🌱 新機能開発チュートリアル</a></li>
+            <li><a href="#tutorial-debug" data-category="tutorial-debug">🐛 デバッグチュートリアル</a></li>
+            <li style="margin-top: 15px; margin-bottom: 15px; border-top: 1px solid #ddd;"></li>
+            <li><a href="#docker" data-category="docker">🐳 Docker リファレンス</a></li>
+            <li><a href="#gem" data-category="gem">💎 Gem リファレンス</a></li>
+            <li><a href="#linux" data-category="linux">🐧 Linux リファレンス</a></li>
+            <li><a href="#git" data-category="git">📦 Git リファレンス</a></li>
+            <li><a href="#github" data-category="github">🐙 GitHub リファレンス</a></li>
+            <li><a href="#rails" data-category="rails">🛤️ Rails リファレンス</a></li>
+            <li><a href="#ruby" data-category="ruby">💎 Ruby リファレンス</a></li>
+            <li><a href="#gem-library" data-category="gem-library">📚 Gem Libraryリファレンス</a></li>
+            <li><a href="#mvc" data-category="mvc">🏗️ MVC パターンリファレンス</a></li>
+            <li><a href="#debug" data-category="debug">🐛 デバッグリファレンス</a></li>
+            <li><a href="#database" data-category="database">🗄️ データベースリファレンス</a></li>
+            <li><a href="#testing" data-category="testing">🧪 テストリファレンス</a></li>
+            <li><a href="#performance" data-category="performance">⚡ パフォーマンスリファレンス</a></li>
+            <li><a href="#errors" data-category="errors">🚨 エラーパターンリファレンス</a></li>
+            <li><a href="#http" data-category="http">🌐 HTTPリファレンス</a></li>
         </ul>
     </nav>
 
     <main class="content">
-        <section id="setup" class="category">
-            <h2>🚀 開発環境のセットアップ</h2>
-            <div class="workflow-card">
-                <h3>はじめに：Dockerを使ったモダンな開発環境</h3>
-                <p>このガイドでは、Dockerを使って、クリーンで再現性の高いRails開発環境を立ち上げる手順を解説します。あなたのPCを汚さずに、プロジェクト専用の仮想環境を構築できます。</p>
 
-                <h4>✅ 前提条件</h4>
-                <p>このフローを始める前に、プロジェクトのルートディレクトリに以下の2つのファイルが用意されている必要があります。</p>
-                <ul>
-                    <li><code><b>Dockerfile</b></code>: Railsアプリを動かすための環境（Ruby, Node.js, ライブラリ等）を定義する設計図です。</li>
-                    <li><code><b>docker-compose.yml</b></code>: Railsコンテナやデータベースコンテナなど、複数のサービスをまとめて管理するための設定ファイルです。特に以下の設定が重要です。
-                        <ul>
-                            <li><b>ports:</b> <code>"3000:3000"</code> のような設定で、PCのブラウザからコンテナ内のRailsサーバーにアクセスできるようにします。</li>
-                            <li><b>volumes:</b> <code>".:/app"</code> のような設定で、PC上のコードとコンテナ内のコードを同期させ、変更が即座に反映されるようにします。</li>
-                        </ul>
-                    </li>
-                </ul>
+        <section id="tutorial-setup" class="category">
+            <h2>🚀 環境構築チュートリアル</h2>
+            <div class="tutorial-card">
+                <h3>Dockerを使ったモダンなRails開発環境</h3>
+                <p>このガイドでは、Dockerを使って、クリーンで再現性の高いRails開発環境を立ち上げる典型的な手順を解説します。各コマンドをクリックすると、ページ下部の詳細なリファレンスにジャンプします。</p>
 
-                <hr>
-
-                <h3>ステップ1: <code>docker compose build</code> - 環境の構築</h3>
-                <p>まず、設計図（<code>Dockerfile</code>）を元に、Railsアプリ専用の環境（イメージ）を構築します。</p>
-                <code>docker compose build</code>
-                <p>ターミナルにたくさんのログが流れますが、これはRubyや必要なライブラリをインストールしている証拠です。エラーなく終了すれば、準備は万端です。</p>
-
-                <hr>
-
-                <h3>ステップ2: <code>docker compose up -d</code> - コンテナの起動</h3>
-                <p>次に、構築したイメージを元にコンテナ（仮想PC）を起動します。<code>-d</code> オプションを付けると、バックグラウンドで起動してくれるのでターミナルが占領されません。</p>
-                <code>docker compose up -d</code>
-                <p><b>✨ 便利コマンド:</b> <code>docker ps</code> を実行すると、起動中のコンテナの一覧（STATUSが `running` や `up` になっているか）を確認できます。</p>
-
-                <hr>
-
-                <h3>ステップ3: <code>docker compose exec web bash</code> - コンテナに入る</h3>
-                <p>起動したコンテナの中に入り、Railsコマンドなどを実行できるようにします。<code>web</code> の部分は、<code>docker-compose.yml</code> で定義したサービス名に合わせます。</p>
-                <code>docker compose exec web bash</code>
-                <p>プロンプトが <code>root@...</code> のように変われば、コンテナ内にログイン成功です。</p>
-
-                <hr>
-
-                <h3>ステップ4: <code>bin/rails db:setup</code> - データベースの準備</h3>
-                <p>コンテナの中で、データベースの作成と初期データの投入を行います。これにより、アプリがデータを読み書きできるようになります。</p>
-                <code>bin/rails db:setup</code>
-                <p><code>Created database...</code> や <code>start create users...</code> のようなログが表示されれば成功です。</p>
-
-                <hr>
-
-                <h3>ステップ5: 開発サーバーの起動（2つのターミナルを使おう！）</h3>
-                <p>いよいよアプリケーションを起動します。最近のRailsでは、フロントエンド（JavaScript）とバックエンド（Rails）を別々のプロセスで動かすのが一般的です。<b>新しいターミナルをもう一つ開いて</b>、それぞれでコマンドを実行しましょう。</p>
-
-                <div class="terminal-split">
-                    <div class="terminal">
-                        <h4>ターミナル1: フロントエンド用</h4>
-                        <p>まずコンテナに入り、JavaScriptのファイルを監視・ビルドするプロセスを起動します。</p>
-                        <code>docker compose exec web bash</code>
-                        <code>yarn build --watch</code>
-                        <p><code>watching for changes...</code> と表示されたら、このターミナルはこのままにしておきます。</p>
-                    </div>
-                    <div class="terminal">
-                        <h4>ターミナル2: バックエンド用</h4>
-                        <p>新しいターミナルで再度コンテナに入り、Railsサーバーを起動します。</p>
-                        <code>docker compose exec web bash</code>
-                        <code>bin/rails s -b 0.0.0.0</code>
-                        <p><code>-b 0.0.0.0</code> は、コンテナの外（あなたのPC）からアクセスするために必要なおまじないです。</p>
-                    </div>
+                <div class="prerequisites">
+                    <h4>✅ 前提条件</h4>
+                    <p>このフローを始める前に、プロジェクトのルートディレクトリに<code>Dockerfile</code>と<code>docker-compose.yml</code>が用意されている必要があります。</p>
                 </div>
 
-                <hr>
-
-                <h3>ステップ6: <code>http://localhost:3000</code> - アプリケーションの確認</h3>
-                <p>おめでとうございます！🎉 全ての準備が整いました。お使いのブラウザで <a href="http://localhost:3000" target="_blank">http://localhost:3000</a> にアクセスして、アプリケーションが表示されるか確認しましょう！</p>
-
-                <hr>
-
-                <h3>開発の終了方法</h3>
-                <p>作業を終えるときは、以下の手順でクリーンに終了させましょう。</p>
                 <ol>
-                    <li>各ターミナルで <code>Ctrl + C</code> を押して、Railsサーバーとyarnのプロセスを停止します。</li>
-                    <li>コンテナを完全に停止・削除するために、以下のコマンドを実行します。これにより、リソースの無駄遣いを防げます。</li>
+                    <li>
+                        <strong>環境の構築:</strong> 設計図（Dockerfile）を元に、Railsアプリ専用の環境（イメージ）を構築します。<br>
+                        <a href="#cmd-docker-compose-build"><code>docker compose build</code></a>
+                    </li>
+                    <li>
+                        <strong>コンテナの起動:</strong> 構築したイメージを元にコンテナ（仮想PC）をバックグラウンドで起動します。<br>
+                        <a href="#cmd-docker-compose-up"><code>docker compose up -d</code></a>
+                    </li>
+                    <li>
+                        <strong>データベースの準備:</strong> コンテナの中に入り、データベースの作成と初期データの投入を行います。<br>
+                        <a href="#cmd-docker-exec-it"><code>docker compose exec web bash</code></a> → <a href="#cmd-rails-db-create"><code>rails db:create</code></a> → <a href="#cmd-rails-db-migrate"><code>rails db:migrate</code></a>
+                    </li>
+                    <li>
+                        <strong>開発サーバーの起動:</strong> フロントエンドとバックエンド、2つのターミナルでそれぞれサーバーを起動します。<br>
+                        (ターミナル1) <a href="#cmd-docker-exec-it"><code>docker compose exec web bash</code></a> → <code>yarn build --watch</code><br>
+                        (ターミナル2) <a href="#cmd-docker-exec-it"><code>docker compose exec web bash</code></a> → <a href="#cmd-rails-server"><code>bin/rails s -b 0.0.0.0</code></a>
+                    </li>
+                    <li>
+                        <strong>アプリケーションの確認:</strong> ブラウザで <a href="http://localhost:3000" target="_blank">http://localhost:3000</a> にアクセスします。
+                    </li>
+                    <li>
+                        <strong>開発の終了:</strong> 各サーバーを<code>Ctrl+C</code>で停止し、コンテナを完全に終了させます。<br>
+                        <a href="#cmd-docker-compose-down"><code>docker compose down</code></a>
+                    </li>
                 </ol>
-                <code>docker compose down</code>
-                <p><b>✨ 便利コマンド:</b> コンテナのログを見たいときは <code>docker compose logs -f web</code> が役立ちます。<code>-f</code> を付けるとリアルタイムでログを追跡できます。</p>
-            </div>
-            <div class="commands-grid">
-                <div class="command-card">
-                    <h3>イメージ一覧</h3>
-                    <code>docker images</code>
-                    <p>ダウンロード済みのイメージを表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>Docker Compose起動</h3>
-                    <code>docker-compose up</code>
-                    <p>複数コンテナを一括起動</p>
-                </div>
-                <div class="command-card">
-                    <h3>Docker Compose停止</h3>
-                    <code>docker-compose down</code>
-                    <p>複数コンテナを一括停止</p>
-                </div>
-                <div class="command-card">
-                    <h3>Docker Composeでbundle install</h3>
-                    <code>docker compose run web bundle install</code>
-                    <p>コンテナ内でGemをインストール</p>
-                </div>
-                <div class="command-card">
-                    <h3>Gemインストール</h3>
-                    <code>gem install [gem名]</code>
-                    <p>特定のGemをインストール</p>
-                </div>
-                <div class="command-card">
-                    <h3>Bundlerでインストール</h3>
-                    <code>bundle install</code>
-                    <p>Gemfileに記載のGemをインストール</p>
-                </div>
-                <div class="command-card">
-                    <h3>ディレクトリ作成</h3>
-                    <code>mkdir [ディレクトリ名]</code>
-                    <p>新しいディレクトリを作成</p>
-                </div>
-                <div class="command-card">
-                    <h3>空ファイル作成</h3>
-                    <code>touch [ファイル名]</code>
-                    <p>ファイルのタイムスタンプを更新、または空ファイルを作成</p>
-                </div>
-                <div class="command-card">
-                    <h3>リポジトリ初期化</h3>
-                    <code>git init</code>
-                    <p>新しいGitリポジトリを作成</p>
-                </div>
-                <div class="command-card">
-                    <h3>クローン</h3>
-                    <code>git clone [URL]</code>
-                    <p>リモートリポジトリをコピー</p>
-                </div>
-                <div class="command-card">
-                    <h3>リモートリポジトリ追加</h3>
-                    <code>git remote add [名前] [URL]</code>
-                    <p>新しいリモートリポジトリを登録</p>
-                </div>
-                <div class="command-card">
-                    <h3>グローバル設定</h3>
-                    <code>git config --global user.name "名前"</code>
-                    <p>システム全体に適用されるGit設定を行う</p>
-                </div>
-                <div class="command-card">
-                    <h3>認証</h3>
-                    <code>gh auth login</code>
-                    <p>GitHubにログイン</p>
-                </div>
-                <div class="command-card">
-                    <h3>リポジトリ作成</h3>
-                    <code>gh repo create [名前]</code>
-                    <p>新しいリポジトリを作成</p>
-                </div>
-                <div class="command-card">
-                    <h3>リポジトリクローン</h3>
-                    <code>gh repo clone [リポジトリ]</code>
-                    <p>リポジトリをクローン</p>
-                </div>
-                <div class="command-card">
-                    <h3>新規アプリ作成</h3>
-                    <code>rails new [アプリ名]</code>
-                    <p>新しいRailsアプリを作成</p>
-                </div>
-                <div class="command-card">
-                    <h3>Dotenv - 環境変数</h3>
-                    <code>gem 'dotenv-rails'</code>
-                    <p>環境変数の管理</p>
-                </div>
             </div>
         </section>
 
-        <section id="workflow" class="category">
-            <h2>🌱 日常の開発フロー</h2>
+        <section id="tutorial-feature" class="category">
+            <h2>🌱 新機能開発チュートリアル</h2>
+            <div class="tutorial-card">
+                <h3>一般的な機能開発の基本的な流れ</h3>
+                <p>新しい機能を追加する際の、典型的なコマンドの流れをまとめました。各コマンドをクリックすると、詳細なリファレンスにジャンプします。</p>
+                <ol>
+                    <li>新しい作業用のブランチを作成します: <a href="#cmd-git-checkout-b"><code>git checkout -b [ブランチ名]</code></a></li>
+                    <li>必要なモデルを生成します: <a href="#cmd-rails-g-model"><code>rails g model [モデル名] [カラム...]</code></a></li>
+                    <li>必要なコントローラーを生成します: <a href="#cmd-rails-g-controller"><code>rails g controller [名前] [アクション...]</code></a></li>
+                    <li>データベースの構造を更新します: <a href="#cmd-rails-db-migrate"><code>rails db:migrate</code></a></li>
+                    <li>(エディタでコードを編集します)</li>
+                    <li>変更をステージングします: <a href="#cmd-git-add-dot"><code>git add .</code></a></li>
+                    <li>変更をコミットします: <a href="#cmd-git-commit-m"><code>git commit -m "メッセージ"</code></a></li>
+                    <li>リモートリポジトリに変更を送信します: <a href="#cmd-git-push"><code>git push origin [ブランチ名]</code></a></li>
+                    <li>GitHubでプルリクエストを作成します: <a href="#cmd-gh-pr-create"><code>gh pr create</code></a></li>
+                </ol>
+            </div>
+        </section>
+
+        <section id="tutorial-debug" class="category">
+            <h2>🐛 デバッグチュートリアル</h2>
+            <div class="tutorial-card">
+                <h3>バグや問題を調査するときの基本的な流れ</h3>
+                <p>何か問題が起きた際の、原因調査のための典型的なコマンドの流れです。各コマンドをクリックすると、詳細なリファレンスにジャンプします。</p>
+                <ol>
+                    <li>何が起きているか、ログの最後の部分を確認します: <a href="#cmd-tail"><code>tail -f log/development.log</code></a></li>
+                    <li>最近の変更履歴を確認し、原因のあたりをつけます: <a href="#cmd-git-log-oneline"><code>git log --oneline</code></a></li>
+                    <li>特定のファイルの変更差分を確認します: <a href="#cmd-git-diff"><code>git diff [ファイル名]</code></a></li>
+                    <li>怪しい箇所にデバッガを仕込み、実行を一時停止します: <a href="#cmd-binding-pry"><code>binding.pry</code></a></li>
+                    <li>Railsコンソールを起動し、データを直接確認・操作します: <a href="#cmd-rails-console"><code>rails console</code></a></li>
+                    <li>実行中のプロセスを確認し、不要なプロセスを停止します: <a href="#cmd-ps-aux"><code>ps aux</code></a> → <a href="#cmd-kill"><code>kill [プロセスID]</code></a></li>
+                </ol>
+            </div>
+        </section>
+
+        <section id="docker" class="category">
+            <h2 style="border-bottom: 2px solid #ddd; padding-bottom: 10px; margin-top: 40px;">🐳 Docker リファレンス</h2>
             <div class="commands-grid">
-                <div class="command-card">
+                <div class="command-card" id="cmd-docker-ps">
                     <h3>コンテナ一覧表示</h3>
                     <code>docker ps</code>
                     <p>実行中のコンテナを表示</p>
                 </div>
-                <div class="command-card">
+                <div class="command-card" id="cmd-docker-ps-a">
                     <h3>すべてのコンテナ表示</h3>
                     <code>docker ps -a</code>
                     <p>停止中も含めてすべて表示</p>
                 </div>
-                <div class="command-card">
+                <div class="command-card" id="cmd-docker-images">
+                    <h3>イメージ一覧</h3>
+                    <code>docker images</code>
+                    <p>ダウンロード済みのイメージを表示</p>
+                </div>
+                <div class="command-card" id="cmd-docker-start">
                     <h3>コンテナ起動</h3>
                     <code>docker start [コンテナ名]</code>
                     <p>停止中のコンテナを起動</p>
                 </div>
-                <div class="command-card">
+                <div class="command-card" id="cmd-docker-stop">
                     <h3>コンテナ停止</h3>
                     <code>docker stop [コンテナ名]</code>
                     <p>実行中のコンテナを停止</p>
                 </div>
-                <div class="command-card">
-                    <h3>コンテナ内でコマンド実行</h3>
-                    <code>docker exec -it [コンテナ名] bash</code>
-                    <p>コンテナ内に入る</p>
-                </div>
-                <div class="command-card">
-                    <h3>Docker Compose再起動</h3>
-                    <code>docker compose restart</code>
-                    <p>全コンテナを再起動</p>
-                </div>
-                <div class="command-card">
-                    <h3>Docker Composeで開発サーバー起動</h3>
-                    <code>docker compose exec web bin/dev</code>
-                    <p>コンテナ内で開発サーバーを起動</p>
-                </div>
-                <div class="command-card">
-                    <h3>Docker Composeでコントローラー生成</h3>
-                    <code>docker compose exec web rails g controller users</code>
-                    <p>usersコントローラーを生成</p>
-                </div>
-                <div class="command-card">
-                    <h3>Docker Composeでセッションコントローラー生成</h3>
-                    <code>docker compose exec web rails g controller user_sessions</code>
-                    <p>user_sessionsコントローラーを生成</p>
-                </div>
-                <div class="command-card">
-                    <h3>RuboCopで自動修正</h3>
-                    <code>docker compose exec web bundle exec rubocop -A</code>
-                    <p>コードスタイルを自動で修正</p>
-                </div>
-                <div class="command-card">
-                    <h3>Gemの更新</h3>
-                    <code>gem update [gem名]</code>
-                    <p>特定のGemを最新版に更新</p>
-                </div>
-                <div class="command-card">
-                    <h3>Bundle更新</h3>
-                    <code>bundle update</code>
-                    <p>すべてのGemを更新</p>
-                </div>
-                <div class="command-card">
-                    <h3>Gemを検索</h3>
-                    <code>gem search [キーワード]</code>
-                    <p>リポジトリからGemを検索</p>
-                </div>
-                <div class="command-card">
-                    <h3>ディレクトリ内容表示</h3>
-                    <code>ls</code>
-                    <p>現在のディレクトリのファイル一覧</p>
-                </div>
-                <div class="command-card">
-                    <h3>詳細表示</h3>
-                    <code>ls -la</code>
-                    <p>隠しファイルを含む詳細情報</p>
-                </div>
-                <div class="command-card">
-                    <h3>ディレクトリ移動</h3>
-                    <code>cd [ディレクトリ名]</code>
-                    <p>指定ディレクトリへ移動</p>
-                </div>
-                <div class="command-card">
-                    <h3>現在地表示</h3>
-                    <code>pwd</code>
-                    <p>現在のディレクトリパスを表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>ファイルコピー</h3>
-                    <code>cp [元] [先]</code>
-                    <p>ファイルをコピー</p>
-                </div>
-                <div class="command-card">
-                    <h3>ファイル移動</h3>
-                    <code>mv [元] [先]</code>
-                    <p>ファイルを移動または名前変更</p>
-                </div>
-                <div class="command-card">
-                    <h3>ファイル内容表示</h3>
-                    <code>cat [ファイル名]</code>
-                    <p>ファイルの内容を表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>ファイル先頭表示</h3>
-                    <code>head [ファイル名]</code>
-                    <p>ファイルの先頭部分を表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>テキスト出力</h3>
-                    <code>echo "テキスト"</code>
-                    <p>指定した文字列や変数の内容を標準出力に表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>コマンド履歴</h3>
-                    <code>history</code>
-                    <p>実行したコマンドの履歴を表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>日時表示</h3>
-                    <code>date</code>
-                    <p>現在の日付と時刻を表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>ステータス確認</h3>
-                    <code>git status</code>
-                    <p>変更状況を確認</p>
-                </div>
-                <div class="command-card">
-                    <h3>ファイル追加</h3>
-                    <code>git add .</code>
-                    <p>すべての変更をステージング</p>
-                </div>
-                <div class="command-card">
-                    <h3>特定ファイル追加</h3>
-                    <code>git add [ファイル名]</code>
-                    <p>指定したファイルのみステージング</p>
-                </div>
-                <div class="command-card">
-                    <h3>コミット</h3>
-                    <code>git commit -m "メッセージ"</code>
-                    <p>変更を記録</p>
-                </div>
-                <div class="command-card">
-                    <h3>プッシュ</h3>
-                    <code>git push origin main</code>
-                    <p>リモートに送信</p>
-                </div>
-                <div class="command-card">
-                    <h3>ブランチをプッシュ</h3>
-                    <code>git push [リモート名] [ブランチ名]</code>
-                    <p>指定したブランチをリモートにプッシュ</p>
-                </div>
-                <div class="command-card">
-                    <h3>プル</h3>
-                    <code>git pull</code>
-                    <p>リモートから取得</p>
-                </div>
-                <div class="command-card">
-                    <h3>ブランチをプル</h3>
-                    <code>git pull [リモート名] [ブランチ名]</code>
-                    <p>指定したブランチをリモートからプル</p>
-                </div>
-                <div class="command-card">
-                    <h3>ブランチ一覧</h3>
-                    <code>git branch</code>
-                    <p>ブランチの一覧表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>ブランチ作成</h3>
-                    <code>git branch [ブランチ名]</code>
-                    <p>新しいブランチを作成（切替はなし）</p>
-                </div>
-                <div class="command-card">
-                    <h3>ブランチ作成・切替</h3>
-                    <code>git checkout -b [ブランチ名]</code>
-                    <p>新しいブランチを作成して切替</p>
-                </div>
-                <div class="command-card">
-                    <h3>ブランチ切替</h3>
-                    <code>git checkout [ブランチ名]</code>
-                    <p>既存のブランチに切り替え</p>
-                </div>
-                <div class="command-card">
-                    <h3>マージ</h3>
-                    <code>git merge [ブランチ名]</code>
-                    <p>ブランチを統合</p>
-                </div>
-                <div class="command-card">
-                    <h3>フェッチ</h3>
-                    <code>git fetch</code>
-                    <p>リモートから最新情報を取得（マージなし）</p>
-                </div>
-                <div class="command-card">
-                    <h3>スタッシュ</h3>
-                    <code>git stash</code>
-                    <p>変更を一時保存</p>
-                </div>
-                <div class="command-card">
-                    <h3>スタッシュの適用</h3>
-                    <code>git stash pop</code>
-                    <p>一時保存した変更を復元</p>
-                </div>
-                <div class="command-card">
-                    <h3>スタッシュ一覧</h3>
-                    <code>git stash list</code>
-                    <p>一時保存した変更の一覧を表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>ログ表示</h3>
-                    <code>git log --oneline</code>
-                    <p>コミット履歴を一行表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>ログ詳細表示</h3>
-                    <code>git log</code>
-                    <p>コミット履歴を詳細表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>グラフ形式ログ</h3>
-                    <code>git log --oneline --graph</code>
-                    <p>履歴をグラフ形式で一行表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>リモートリポジトリ確認</h3>
-                    <code>git remote -v</code>
-                    <p>リモートリポジトリの一覧表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>ローカルブランチ削除</h3>
-                    <code>git branch -d [ブランチ名]</code>
-                    <p>マージ済みのローカルブランチを削除</p>
-                </div>
-                <div class="command-card">
-                    <h3>リモートブランチ削除</h3>
-                    <code>git push origin --delete [ブランチ名]</code>
-                    <p>リモートリポジトリのブランチを削除</p>
-                </div>
-                <div class="command-card">
-                    <h3>全ブランチ一覧</h3>
-                    <code>git branch -a</code>
-                    <p>リモートを含む全ブランチを表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>ファイル削除</h3>
-                    <code>git rm [ファイル名]</code>
-                    <p>ファイルをリポジトリとワーキングツリーから削除</p>
-                </div>
-                <div class="command-card">
-                    <h3>ファイル移動</h3>
-                    <code>git mv [元] [先]</code>
-                    <p>ファイルの移動またはリネームを記録</p>
-                </div>
-                <div class="command-card">
-                    <h3>PR作成</h3>
-                    <code>gh pr create</code>
-                    <p>プルリクエストを作成</p>
-                </div>
-                <div class="command-card">
-                    <h3>PR一覧</h3>
-                    <code>gh pr list</code>
-                    <p>プルリクエスト一覧</p>
-                </div>
-                <div class="command-card">
-                    <h3>Issue作成</h3>
-                    <code>gh issue create</code>
-                    <p>新しいIssueを作成</p>
-                </div>
-                <div class="command-card">
-                    <h3>Issue一覧</h3>
-                    <code>gh issue list</code>
-                    <p>Issue一覧を表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>サーバー起動</h3>
-                    <code>rails server</code>
-                    <p>開発サーバーを起動</p>
-                </div>
-                <div class="command-card">
-                    <h3>コンソール起動</h3>
-                    <code>rails console</code>
-                    <p>Railsコンソールを起動</p>
-                </div>
-                <div class="command-card">
-                    <h3>モデル生成</h3>
-                    <code>rails g model [モデル名]</code>
-                    <p>新しいモデルを生成</p>
-                </div>
-                <div class="command-card">
-                    <h3>コントローラー生成</h3>
-                    <code>rails g controller [名前]</code>
-                    <p>新しいコントローラーを生成</p>
-                </div>
-                <div class="command-card">
-                    <h3>Scaffold生成</h3>
-                    <code>rails g scaffold [名前]</code>
-                    <p>CRUD機能を一括生成</p>
-                </div>
-                <div class="command-card">
-                    <h3>ルート確認</h3>
-                    <code>rails routes</code>
-                    <p>ルーティング一覧を表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>Rubocop - コード検査</h3>
-                    <code>gem 'rubocop'</code>
-                    <p>コードスタイルチェッカー</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="db" class="category">
-            <h2>🗄️ データベース操作</h2>
-            <div class="commands-grid">
-                <div class="command-card">
-                    <h3>Docker Composeでマイグレーション</h3>
-                    <code>docker compose exec web rails db:migrate</code>
-                    <p>コンテナ内でDBマイグレーション実行</p>
-                </div>
-                <div class="command-card">
-                    <h3>Docker Composeでマイグレーション状態確認</h3>
-                    <code>docker compose exec web rails db:migrate:status</code>
-                    <p>マイグレーションの適用状態を確認</p>
-                </div>
-                <div class="command-card">
-                    <h3>MySQLコンテナに接続</h3>
-                    <code>docker exec -it [コンテナ名] mysql -u [ユーザー] -p</code>
-                    <p>実行中のMySQLコンテナに接続してSQL操作</p>
-                </div>
-                <div class="command-card">
-                    <h3>PostgreSQLコンテナに接続</h3>
-                    <code>docker exec -it [コンテナ名] psql -U [ユーザー] -d [DB名]</code>
-                    <p>実行中のPostgreSQLコンテナに接続してSQL操作</p>
-                </div>
-                <div class="command-card">
-                    <h3>DB作成</h3>
-                    <code>rails db:create</code>
-                    <p>データベースを作成</p>
-                </div>
-                <div class="command-card">
-                    <h3>マイグレーション実行</h3>
-                    <code>rails db:migrate</code>
-                    <p>DBマイグレーションを実行</p>
-                </div>
-                <div class="command-card">
-                    <h3>ロールバック</h3>
-                    <code>rails db:rollback</code>
-                    <p>マイグレーションを戻す</p>
-                </div>
-                <div class="command-card">
-                    <h3>シード実行</h3>
-                    <code>rails db:seed</code>
-                    <p>初期データを投入</p>
-                </div>
-                <div class="command-card">
-                    <h3>DB接続確認</h3>
-                    <code>rails db:version</code>
-                    <p>現在のDBバージョンを確認</p>
-                </div>
-                <div class="command-card">
-                    <h3>DBリセット</h3>
-                    <code>rails db:reset</code>
-                    <p>DBを削除して再作成</p>
-                </div>
-                <div class="command-card">
-                    <h3>DBスキーマ読み込み</h3>
-                    <code>rails db:schema:load</code>
-                    <p>schema.rbからDBを構築</p>
-                </div>
-                <div class="command-card">
-                    <h3>DBシード実行</h3>
-                    <code>rails db:seed:replant</code>
-                    <p>データを削除してシード再実行</p>
-                </div>
-                <div class="command-card">
-                    <h3>特定マイグレーション実行</h3>
-                    <code>rails db:migrate:up VERSION=20231201</code>
-                    <p>特定のマイグレーションを実行</p>
-                </div>
-                <div class="command-card">
-                    <h3>マイグレーション状態確認</h3>
-                    <code>rails db:migrate:status</code>
-                    <p>各マイグレーションの適用状態</p>
-                </div>
-                <div class="command-card">
-                    <h3>DBコンソール起動</h3>
-                    <code>rails dbconsole</code>
-                    <p>データベースのCLIに接続</p>
-                </div>
-                <div class="command-card">
-                    <h3>DBダンプ作成</h3>
-                    <code>rails db:schema:dump</code>
-                    <p>現在のDBスキーマを出力</p>
-                </div>
-                <div class="command-card">
-                    <h3>PostgreSQL接続</h3>
-                    <code>psql -d database_name</code>
-                    <p>PostgreSQLコンソールに接続</p>
-                </div>
-                <div class="command-card">
-                    <h3>MySQL接続</h3>
-                    <code>mysql -u root -p database_name</code>
-                    <p>MySQLコンソールに接続</p>
-                </div>
-                <div class="command-card">
-                    <h3>SQLite3接続</h3>
-                    <code>sqlite3 db/development.sqlite3</code>
-                    <p>SQLite3データベースに接続</p>
-                </div>
-                <div class="command-card">
-                    <h3>ActiveRecord SQL実行</h3>
-                    <code>ActiveRecord::Base.connection.execute("SQL")</code>
-                    <p>生SQLを直接実行</p>
-                </div>
-                <div class="command-card">
-                    <h3>データベースインデックス</h3>
-                    <code>add_index :users, [:email, :created_at]</code>
-                    <p>複合インデックスで検索高速化</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="testing" class="category">
-            <h2>✅ テストと品質管理</h2>
-            <div class="commands-grid">
-                <div class="command-card">
-                    <h3>テスト実行</h3>
-                    <code>rails test</code>
-                    <p>テストスイートを実行</p>
-                </div>
-                <div class="command-card">
-                    <h3>RSpec - テスト</h3>
-                    <code>gem 'rspec-rails'</code>
-                    <p>BDDテストフレームワーク</p>
-                </div>
-                <div class="command-card">
-                    <h3>FactoryBot - テストデータ</h3>
-                    <code>gem 'factory_bot_rails'</code>
-                    <p>テスト用データの生成</p>
-                </div>
-                <div class="command-card">
-                    <h3>Faker - ダミーデータ</h3>
-                    <code>gem 'faker'</code>
-                    <p>リアルなダミーデータを生成</p>
-                </div>
-                <div class="command-card">
-                    <h3>全テスト実行</h3>
-                    <code>rails test</code>
-                    <p>すべてのテストを実行</p>
-                </div>
-                <div class="command-card">
-                    <h3>特定テスト実行</h3>
-                    <code>rails test test/models/user_test.rb</code>
-                    <p>特定のテストファイルを実行</p>
-                </div>
-                <div class="command-card">
-                    <h3>RSpec実行</h3>
-                    <code>bundle exec rspec</code>
-                    <p>RSpecテストを実行</p>
-                </div>
-                <div class="command-card">
-                    <h3>特定スペック実行</h3>
-                    <code>rspec spec/models/user_spec.rb:10</code>
-                    <p>特定の行のテストを実行</p>
-                </div>
-                <div class="command-card">
-                    <h3>テストDB準備</h3>
-                    <code>rails db:test:prepare</code>
-                    <p>テスト用DBを準備</p>
-                </div>
-                <div class="command-card">
-                    <h3>カバレッジ確認</h3>
-                    <code>open coverage/index.html</code>
-                    <p>テストカバレッジレポートを確認</p>
-                </div>
-                <div class="command-card">
-                    <h3>Factory作成</h3>
-                    <code>FactoryBot.create(:user)</code>
-                    <p>テストデータを作成</p>
-                </div>
-                <div class="command-card">
-                    <h3>システムテスト実行</h3>
-                    <code>rails test:system</code>
-                    <p>ブラウザを使った統合テスト</p>
-                </div>
-                <div class="command-card">
-                    <h3>並列テスト実行</h3>
-                    <code>rails test -j 4</code>
-                    <p>4つのプロセスで並列実行</p>
-                </div>
-                <div class="command-card">
-                    <h3>Guard自動テスト</h3>
-                    <code>bundle exec guard</code>
-                    <p>ファイル変更を監視して自動テスト</p>
-                </div>
-                <div class="command-card">
-                    <h3>テストのみ実行（失敗のみ）</h3>
-                    <code>rspec --only-failures</code>
-                    <p>前回失敗したテストのみ実行</p>
-                </div>
-                <div class="command-card">
-                    <h3>テストのシード値固定</h3>
-                    <code>rspec --seed 12345</code>
-                    <p>ランダムテストの順序を固定</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="debugging" class="category">
-            <h2>🐛 デバッグと問題解決</h2>
-            <div class="commands-grid">
-                <div class="command-card">
-                    <h3>コンテナにアタッチ</h3>
-                    <code>docker attach [コンテナID]</code>
-                    <p>実行中のコンテナに接続。デタッチは Ctrl+P, Ctrl+Q</p>
-                </div>
-                <div class="command-card">
-                    <h3>インストール済み一覧</h3>
-                    <code>gem list</code>
-                    <p>インストール済みGemの一覧</p>
-                </div>
-                <div class="command-card">
-                    <h3>Gemの情報表示</h3>
-                    <code>gem info [gem名]</code>
-                    <p>Gemの詳細情報を表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>プロセス表示</h3>
-                    <code>ps aux</code>
-                    <p>実行中のプロセス一覧</p>
-                </div>
-                <div class="command-card">
-                    <h3>差分表示</h3>
-                    <code>diff [ファイル1] [ファイル2]</code>
-                    <p>2つのファイル間の差分を表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>ファイル末尾表示</h3>
-                    <code>tail [ファイル名]</code>
-                    <p>ファイルの末尾部分を表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>プロセス終了</h3>
-                    <code>kill [プロセスID]</code>
-                    <p>指定したプロセスを終了させる</p>
-                </div>
-                <div class="command-card">
-                    <h3>マニュアル表示</h3>
-                    <code>man [コマンド]</code>
-                    <p>コマンドのマニュアルページを表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>コマンドパス表示</h3>
-                    <code>which [コマンド]</code>
-                    <p>コマンドの実行ファイルの場所を特定</p>
-                </div>
-                <div class="command-card">
-                    <h3>ログインユーザー表示</h3>
-                    <code>who</code>
-                    <p>現在システムにログインしているユーザーの一覧を表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>ディスク使用量</h3>
-                    <code>df -h</code>
-                    <p>ディスクの空き容量と使用状況を表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>ファイルサイズ表示</h3>
-                    <code>du -h [ファイル/ディレクトリ]</code>
-                    <p>ファイルやディレクトリのディスク使用量を表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>差分表示</h3>
-                    <code>git diff</code>
-                    <p>変更内容を表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>コミットメッセージ検索</h3>
-                    <code>git log --grep="[パターン]"</code>
-                    <p>コミットメッセージからパターンを検索</p>
-                </div>
-                <div class="command-card">
-                    <h3>最新コミット表示</h3>
-                    <code>git log -n [数]</code>
-                    <p>指定した数だけ最新のコミットを表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>古い順にログ表示</h3>
-                    <code>git log --reverse</code>
-                    <p>コミット履歴を古いものから順に表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>日付順ログ</h3>
-                    <code>git log --date-order</code>
-                    <p>コミットを日付順にソートして表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>マージコミット除外</h3>
-                    <code>git log --no-merges</code>
-                    <p>マージコミットをログ表示から除外</p>
-                </div>
-                <div class="command-card">
-                    <h3>オブジェクト内容表示</h3>
-                    <code>git show [コミット/タグ]</code>
-                    <p>コミットやタグなどのオブジェクト情報を表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>管理ファイル一覧</h3>
-                    <code>git ls-files</code>
-                    <p>Gitが管理しているファイルの一覧を表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>リポジトリルート表示</h3>
-                    <code>git rev-parse --show-toplevel</code>
-                    <p>リポジトリのトップレベルディレクトリのパスを表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>コミット数統計</h3>
-                    <code>git shortlog -sn</code>
-                    <p>コントリビューター毎のコミット数を集計して表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>コントリビューター表示</h3>
-                    <code>git shortlog</code>
-                    <p>コントリビューターのコミット概要を表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>オブジェクト数表示</h3>
-                    <code>git count-objects -v</code>
-                    <p>リポジトリ内のオブジェクト数やサイズを表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>参照履歴表示</h3>
-                    <code>git reflog</code>
-                    <p>HEADやブランチの移動履歴を表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>ヘルプ表示</h3>
-                    <code>git help [コマンド]</code>
-                    <p>指定したGitコマンドのヘルプドキュメントを表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>実行パス表示</h3>
-                    <code>git --exec-path</code>
-                    <p>Gitの内部コマンドが配置されているパスを表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>日付指定ログ</h3>
-                    <code>git log --date=iso</code>
-                    <p>ログの日付フォーマットを指定して表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>Pry - デバッグ</h3>
-                    <code>gem 'pry-rails'</code>
-                    <p>強力なデバッグツール</p>
-                </div>
-                <div class="command-card">
-                    <h3>Letter Opener - メール確認</h3>
-                    <code>gem 'letter_opener'</code>
-                    <p>開発環境でメールを確認</p>
-                </div>
-                <div class="command-card">
-                    <h3>binding.pry挿入</h3>
-                    <code>binding.pry</code>
-                    <p>コードの実行を一時停止してデバッグ</p>
-                </div>
-                <div class="command-card">
-                    <h3>byebugデバッガー</h3>
-                    <code>byebug</code>
-                    <p>ブレークポイントを設定</p>
-                </div>
-                <div class="command-card">
-                    <h3>Rails.logger出力</h3>
-                    <code>Rails.logger.debug "変数: #{@variable}"</code>
-                    <p>ログファイルにデバッグ情報を出力</p>
-                </div>
-                <div class="command-card">
-                    <h3>コンソールでSQL確認</h3>
-                    <code>User.all.to_sql</code>
-                    <p>発行されるSQLクエリを確認</p>
-                </div>
-                <div class="command-card">
-                    <h3>better_errorsエラー画面</h3>
-                    <code>gem 'better_errors'</code>
-                    <p>エラー画面を見やすく改善</p>
-                </div>
-                <div class="command-card">
-                    <h3>rails consoleでデバッグ</h3>
-                    <code>rails c --sandbox</code>
-                    <p>サンドボックスモードで安全にテスト</p>
-                </div>
-                <div class="command-card">
-                    <h3>ログレベル変更</h3>
-                    <code>config.log_level = :debug</code>
-                    <p>詳細なログ情報を出力</p>
-                </div>
-                <div class="command-card">
-                    <h3>Bullet - N+1検出</h3>
-                    <code>gem 'bullet'</code>
-                    <p>N+1問題を自動検出</p>
-                </div>
-                <div class="command-card">
-                    <h3>rack-mini-profiler</h3>
-                    <code>gem 'rack-mini-profiler'</code>
-                    <p>ページ読み込み時間を分析</p>
-                </div>
-                <div class="command-card">
-                    <h3>chrome_logger</h3>
-                    <code>ChromeLogger.debug(variable)</code>
-                    <p>ブラウザコンソールにログ出力</p>
-                </div>
-                <div class="command-card">
-                    <h3>エラーバックトレース</h3>
-                    <code>puts caller</code>
-                    <p>メソッド呼び出し履歴を表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>オブジェクト詳細表示</h3>
-                    <code>pp @user</code>
-                    <p>オブジェクトを見やすく表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>プロファイリング</h3>
-                    <code>ruby-prof</code>
-                    <p>コードの実行時間を詳細分析</p>
-                </div>
-                <div class="command-card">
-                    <h3>メモリ使用量確認</h3>
-                    <code>memory_profiler</code>
-                    <p>メモリリークを検出</p>
-                </div>
-                <div class="command-card">
-                    <h3>NoMethodError</h3>
-                    <code>undefined method 'name' for nil:NilClass</code>
-                    <p>nilオブジェクトにメソッドを呼び出し。&.演算子やif文で対処</p>
-                </div>
-                <div class="command-card">
-                    <h3>NameError</h3>
-                    <code>uninitialized constant User</code>
-                    <p>クラスが定義されていない。ファイル名とクラス名の確認</p>
-                </div>
-                <div class="command-card">
-                    <h3>SyntaxError</h3>
-                    <code>unexpected end-of-input</code>
-                    <p>endの不足やカッコの不一致。インデントを確認</p>
-                </div>
-                <div class="command-card">
-                    <h3>ActiveRecord::RecordNotFound</h3>
-                    <code>Couldn't find User with 'id'=1</code>
-                    <p>存在しないレコード。find_byやrescueで対処</p>
-                </div>
-                <div class="command-card">
-                    <h3>ActiveRecord::RecordInvalid</h3>
-                    <code>Validation failed: Email can't be blank</code>
-                    <p>バリデーションエラー。save!の代わりにsaveを使用</p>
-                </div>
-                <div class="command-card">
-                    <h3>ActionController::ParameterMissing</h3>
-                    <code>param is missing or empty: user</code>
-                    <p>必須パラメータ不足。Strong Parametersを確認</p>
-                </div>
-                <div class="command-card">
-                    <h3>ActionView::MissingTemplate</h3>
-                    <code>Missing template users/index</code>
-                    <p>ビューファイルが存在しない。ファイルパスを確認</p>
-                </div>
-                <div class="command-card">
-                    <h3>LoadError</h3>
-                    <code>cannot load such file -- bcrypt</code>
-                    <p>Gemが見つからない。bundle installを実行</p>
-                </div>
-                <div class="command-card">
-                    <h3>PG::ConnectionBad</h3>
-                    <code>could not connect to server</code>
-                    <p>PostgreSQLが起動していない。brew services start postgresql</p>
-                </div>
-                <div class="command-card">
-                    <h3>Mysql2::Error::ConnectionError</h3>
-                    <code>Can't connect to MySQL server</code>
-                    <p>MySQLが起動していない。sudo service mysql start</p>
-                </div>
-                <div class="command-card">
-                    <h3>ActiveRecord::PendingMigrationError</h3>
-                    <code>Migrations are pending</code>
-                    <p>未実行のマイグレーション。rails db:migrateを実行</p>
-                </div>
-                <div class="command-card">
-                    <h3>ActiveRecord::StatementInvalid</h3>
-                    <code>SQLite3::SQLException: no such column</code>
-                    <p>カラムが存在しない。マイグレーションファイルを確認</p>
-                </div>
-                <div class="command-card">
-                    <h3>ActionController::InvalidAuthenticityToken</h3>
-                    <code>Can't verify CSRF token</code>
-                    <p>CSRFトークンエラー。フォームにcsrf_meta_tagsを追加</p>
-                </div>
-                <div class="command-card">
-                    <h3>Net::ReadTimeout</h3>
-                    <code>execution expired</code>
-                    <p>タイムアウト。タイムアウト時間を延長またはリトライ処理</p>
-                </div>
-                <div class="command-card">
-                    <h3>ActiveRecord::DuplicateEntry</h3>
-                    <code>Duplicate entry for key 'index_users_on_email'</code>
-                    <p>一意制約違反。データの重複を確認</p>
-                </div>
-                <div class="command-card">
-                    <h3>ArgumentError</h3>
-                    <code>wrong number of arguments (given 2, expected 1)</code>
-                    <p>引数の数が違う。メソッド定義を確認</p>
-                </div>
-                <div class="command-card">
-                    <h3>TypeError</h3>
-                    <code>no implicit conversion of Symbol into Integer</code>
-                    <p>型の不一致。配列とハッシュの混同を確認</p>
-                </div>
-                <div class="command-card">
-                    <h3>Bundler::GemNotFound</h3>
-                    <code>Could not find gem 'rails'</code>
-                    <p>Gemが見つからない。bundle installを実行</p>
-                </div>
-                <div class="command-card">
-                    <h3>Webpacker::Manifest::MissingEntryError</h3>
-                    <code>Can't find application.js in manifest.json</code>
-                    <p>Webpackerコンパイルエラー。rails webpacker:compileを実行</p>
-                </div>
-                <div class="command-card">
-                    <h3>ActiveStorage::FileNotFoundError</h3>
-                    <code>Could not find file</code>
-                    <p>アップロードファイルが見つからない。ストレージを確認</p>
-                </div>
-                <div class="command-card">
-                    <h3>Redis::CannotConnectError</h3>
-                    <code>Error connecting to Redis</code>
-                    <p>Redisが起動していない。redis-serverを起動</p>
-                </div>
-                <div class="command-card">
-                    <h3>Errno::EADDRINUSE</h3>
-                    <code>Address already in use - bind(2) port 3000</code>
-                    <p>ポートが使用中。lsof -i:3000でプロセスを確認してkill</p>
-                </div>
-                <div class="command-card">
-                    <h3>ActiveJob::DeserializationError</h3>
-                    <code>Error while trying to deserialize arguments</code>
-                    <p>ジョブの引数エラー。GlobalIDを使用またはIDを渡す</p>
-                </div>
-                <div class="command-card">
-                    <h3>StandardError - カスタムエラー処理</h3>
-                    <code>rescue StandardError => e</code>
-                    <p>汎用的なエラーキャッチ。ログ出力して適切に処理</p>
-                </div>
-            </div>
-        </section>
-
-        <section id="advanced" class="category">
-            <h2>🔧 高度なトピック</h2>
-            <div class="commands-grid">
-                <div class="command-card">
+                <div class="command-card" id="cmd-docker-rm">
                     <h3>コンテナ削除</h3>
                     <code>docker rm [コンテナ名]</code>
                     <p>コンテナを削除</p>
                 </div>
-                <div class="command-card">
+                <div class="command-card" id="cmd-docker-rmi">
                     <h3>イメージ削除</h3>
                     <code>docker rmi [イメージ名]</code>
                     <p>イメージを削除</p>
                 </div>
-                <div class="command-card">
+                <div class="command-card" id="cmd-docker-exec-it">
+                    <h3>コンテナ内でコマンド実行</h3>
+                    <code>docker exec -it [コンテナ名] bash</code>
+                    <p>コンテナ内に入る</p>
+                </div>
+                <div class="command-card" id="cmd-docker-attach">
+                    <h3>コンテナにアタッチ</h3>
+                    <code>docker attach [コンテナID]</code>
+                    <p>実行中のコンテナに接続。デタッチは Ctrl+P, Ctrl+Q</p>
+                </div>
+                <div class="command-card" id="cmd-docker-compose-build">
+                    <h3>Docker Composeビルド</h3>
+                    <code>docker compose build</code>
+                    <p>Dockerfileを元にイメージをビルド</p>
+                </div>
+                <div class="command-card" id="cmd-docker-compose-up">
+                    <h3>Docker Compose起動</h3>
+                    <code>docker-compose up</code>
+                    <p>複数コンテナを一括起動</p>
+                </div>
+                <div class="command-card" id="cmd-docker-compose-down">
+                    <h3>Docker Compose停止</h3>
+                    <code>docker-compose down</code>
+                    <p>複数コンテナを一括停止</p>
+                </div>
+                <div class="command-card" id="cmd-docker-compose-run-bundle-install">
+                    <h3>Docker Composeでbundle install</h3>
+                    <code>docker compose run web bundle install</code>
+                    <p>コンテナ内でGemをインストール</p>
+                </div>
+                <div class="command-card" id="cmd-docker-compose-run-sorcery">
                     <h3>Docker ComposeでSorceryインストール</h3>
                     <code>docker compose run web rails g sorcery:install</code>
                     <p>Sorcery認証機能をセットアップ</p>
                 </div>
-                <div class="command-card">
+                <div class="command-card" id="cmd-docker-compose-restart">
+                    <h3>Docker Compose再起動</h3>
+                    <code>docker compose restart</code>
+                    <p>全コンテナを再起動</p>
+                </div>
+                <div class="command-card" id="cmd-docker-compose-exec-dev">
+                    <h3>Docker Composeで開発サーバー起動</h3>
+                    <code>docker compose exec web bin/dev</code>
+                    <p>コンテナ内で開発サーバーを起動</p>
+                </div>
+                <div class="command-card" id="cmd-docker-compose-exec-migrate">
+                    <h3>Docker Composeでマイグレーション</h3>
+                    <code>docker compose exec web rails db:migrate</code>
+                    <p>コンテナ内でDBマイグレーション実行</p>
+                </div>
+                <div class="command-card" id="cmd-docker-compose-exec-migrate-status">
+                    <h3>Docker Composeでマイグレーション状態確認</h3>
+                    <code>docker compose exec web rails db:migrate:status</code>
+                    <p>マイグレーションの適用状態を確認</p>
+                </div>
+                <div class="command-card" id="cmd-docker-compose-exec-g-controller-users">
+                    <h3>Docker Composeでコントローラー生成</h3>
+                    <code>docker compose exec web rails g controller users</code>
+                    <p>usersコントローラーを生成</p>
+                </div>
+                <div class="command-card" id="cmd-docker-compose-exec-g-controller-sessions">
+                    <h3>Docker Composeでセッションコントローラー生成</h3>
+                    <code>docker compose exec web rails g controller user_sessions</code>
+                    <p>user_sessionsコントローラーを生成</p>
+                </div>
+                <div class="command-card" id="cmd-docker-compose-exec-rubocop">
+                    <h3>RuboCopで自動修正</h3>
+                    <code>docker compose exec web bundle exec rubocop -A</code>
+                    <p>コードスタイルを自動で修正</p>
+                </div>
+                <div class="command-card" id="cmd-docker-exec-mysql">
+                    <h3>MySQLコンテナに接続</h3>
+                    <code>docker exec -it [コンテナ名] mysql -u [ユーザー] -p</code>
+                    <p>実行中のMySQLコンテナに接続してSQL操作</p>
+                </div>
+                <div class="command-card" id="cmd-docker-exec-psql">
+                    <h3>PostgreSQLコンテナに接続</h3>
+                    <code>docker exec -it [コンテナ名] psql -U [ユーザー] -d [DB名]</code>
+                    <p>実行中のPostgreSQLコンテナに接続してSQL操作</p>
+                </div>
+            </div>
+        </section>
+
+        <section id="gem" class="category">
+            <h2 style="border-bottom: 2px solid #ddd; padding-bottom: 10px; margin-top: 40px;">💎 Gem リファレンス</h2>
+            <div class="commands-grid">
+                <div class="command-card" id="cmd-gem-install">
+                    <h3>Gemインストール</h3>
+                    <code>gem install [gem名]</code>
+                    <p>特定のGemをインストール</p>
+                </div>
+                <div class="command-card" id="cmd-gem-uninstall">
                     <h3>Gemアンインストール</h3>
                     <code>gem uninstall [gem名]</code>
                     <p>Gemを削除</p>
                 </div>
-                <div class="command-card">
-                    <h3>ファイル削除</h3>
-                    <code>rm [ファイル名]</code>
-                    <p>ファイルを削除</p>
-                </div>
-                <div class="command-card">
-                    <h3>ディレクトリ削除</h3>
-                    <code>rm -rf [ディレクトリ名]</code>
-                    <p>ディレクトリを強制削除</p>
-                </div>
-                <div class="command-card">
-                    <h3>ファイル検索</h3>
-                    <code>find . -name "[ファイル名]"</code>
-                    <p>ファイルを名前で検索</p>
-                </div>
-                <div class="command-card">
-                    <h3>テキスト検索</h3>
-                    <code>grep "[検索文字]" [ファイル]</code>
-                    <p>ファイル内のテキストを検索</p>
-                </div>
-                <div class="command-card">
-                    <h3>権限変更</h3>
-                    <code>chmod 755 [ファイル名]</code>
-                    <p>ファイルの権限を変更</p>
-                </div>
-                <div class="command-card">
-                    <h3>空ディレクトリ削除</h3>
-                    <code>rmdir [ディレクトリ名]</code>
-                    <p>中身が空のディレクトリを削除</p>
-                </div>
-                <div class="command-card">
-                    <h3>単語・行数カウント</h3>
-                    <code>wc [ファイル名]</code>
-                    <p>ファイル内の行数、単語数、バイト数をカウント</p>
-                </div>
-                <div class="command-card">
-                    <h3>テキストソート</h3>
-                    <code>sort [ファイル名]</code>
-                    <p>テキストファイルの行をソート</p>
-                </div>
-                <div class="command-card">
-                    <h3>重複行の削除</h3>
-                    <code>uniq [ファイル名]</code>
-                    <p>ソート済みファイルから重複する行を削除</p>
-                </div>
-                <div class="command-card">
-                    <h3>所有者変更</h3>
-                    <code>chown [所有者] [ファイル]</code>
-                    <p>ファイルやディレクトリの所有者を変更</p>
-                </div>
-                <div class="command-card">
-                    <h3>アーカイブ作成</h3>
-                    <code>tar -cvf [archive.tar] [ファイル]</code>
-                    <p>複数のファイルを一つのアーカイブにまとめる</p>
-                </div>
-                <div class="command-card">
-                    <h3>ファイル圧縮</h3>
-                    <code>gzip [ファイル名]</code>
-                    <p>ファイルを圧縮（.gz）</p>
-                </div>
-                <div class="command-card">
-                    <h3>環境変数設定</h3>
-                    <code>export VAR=value</code>
-                    <p>環境変数を設定またはエクスポート</p>
-                </div>
-                <div class="command-card">
-                    <h3>エイリアス設定</h3>
-                    <code>alias name='command'</code>
-                    <p>コマンドの別名を定義</p>
-                </div>
-                <div class="command-card">
-                    <h3>ファイルシステムのマウント</h3>
-                    <code>mount</code>
-                    <p>ファイルシステムをマウント（接続）する</p>
-                </div>
-                <div class="command-card">
-                    <h3>アンマウント</h3>
-                    <code>umount [デバイス]</code>
-                    <p>マウントされたファイルシステムを解除</p>
-                </div>
-                <div class="command-card">
-                    <h3>シンボリックリンク作成</h3>
-                    <code>ln -s [元] [リンク名]</code>
-                    <p>ファイルやディレクトリへのシンボリックリンクを作成</p>
-                </div>
-                <div class="command-card">
-                    <h3>ストリームエディタ</h3>
-                    <code>sed 's/old/new/g' [ファイル]</code>
-                    <p>テキストの置換や削除などの編集を行う</p>
-                </div>
-                <div class="command-card">
-                    <h3>テキスト処理</h3>
-                    <code>awk '{print $1}' [ファイル]</code>
-                    <p>テキストを行ごとに処理する強力なプログラミング言語</p>
-                </div>
-                <div class="command-card">
-                    <h3>フィールド抽出</h3>
-                    <code>cut -f1 -d',' [ファイル]</code>
-                    <p>テキストの各行からフィールドを抽出</p>
-                </div>
-                <div class="command-card">
-                    <h3>取り消し</h3>
-                    <code>git reset --hard HEAD</code>
-                    <p>すべての変更を取り消し</p>
-                </div>
-                <div class="command-card">
-                    <h3>リベース</h3>
-                    <code>git rebase [ブランチ名]</code>
-                    <p>ブランチをリベース</p>
-                </div>
-                <div class="command-card">
-                    <h3>コミットまで戻す</h3>
-                    <code>git reset [コミット]</code>
-                    <p>指定コミットまで変更を戻す（--soft, --mixed, --hard）</p>
-                </div>
-                <div class="command-card">
-                    <h3>コミット打ち消し</h3>
-                    <code>git revert [コミット]</code>
-                    <p>指定コミットの変更を打ち消すコミットを作成</p>
-                </div>
-                <div class="command-card">
-                    <h3>直前コミット修正</h3>
-                    <code>git commit --amend</code>
-                    <p>直前のコミットを修正（メッセージやファイル追加）</p>
-                </div>
-                <div class="command-card">
-                    <h3>コミット取り込み</h3>
-                    <code>git cherry-pick [コミットID]</code>
-                    <p>別のブランチから特定のコミットを取り込む</p>
-                </div>
-                <div class="command-card">
-                    <h3>タグ付け</h3>
-                    <code>git tag [タグ名]</code>
-                    <p>特定のコミットにバージョン等のタグを付ける</p>
-                </div>
-                <div class="command-card">
-                    <h3>タグをプッシュ</h3>
-                    <code>git push origin [タグ名]</code>
-                    <p>作成したタグをリモートに送信</p>
-                </div>
-                <div class="command-card">
-                    <h3>リポジトリ内検索</h3>
-                    <code>git grep [パターン]</code>
-                    <p>管理下のファイルから指定パターンを検索</p>
-                </div>
-                <div class="command-card">
-                    <h3>実行権限変更</h3>
-                    <code>git update-index --chmod=+x [ファイル]</code>
-                    <p>ファイルの実行権限をGitに記録</p>
-                </div>
-                <div class="command-card">
-                    <h3>アーカイブ作成</h3>
-                    <code>git archive --format=zip HEAD -o file.zip</code>
-                    <p>リポジトリの内容をzipなどのアーカイブ形式で出力</p>
-                </div>
-                <div class="command-card">
-                    <h3>リポジトリ最適化</h3>
-                    <code>git gc</code>
-                    <p>不要なオブジェクトを削除しリポジトリを最適化</p>
-                </div>
-                <div class="command-card">
-                    <h3>強力な最適化</h3>
-                    <code>git gc --aggressive</code>
-                    <p>より強力なリポジトリの最適化を実行</p>
-                </div>
-                <div class="command-card">
-                    <h3>エイリアス設定</h3>
-                    <code>git config --global alias.st status</code>
-                    <p>Gitコマンドの短縮形（エイリアス）を設定</p>
-                </div>
-                <div class="command-card">
-                    <h3>リモートリポジトリ削除</h3>
-                    <code>git remote remove [名前]</code>
-                    <p>登録されているリモートリポジトリを削除</p>
-                </div>
-                <div class="command-card">
-                    <h3>履歴の書き換え</h3>
-                    <code>git filter-branch --tree-filter 'rm -f passwords.txt' HEAD</code>
-                    <p>全コミット履歴に対してスクリプトを実行し履歴を書き換え</p>
-                </div>
-                <div class="command-card">
-                    <h3>ログフォーマット指定</h3>
-                    <code>git log --format="%h - %an, %ar : %s"</code>
-                    <p>ログの出力フォーマットをカスタマイズ</p>
-                </div>
-                <div class="command-card">
-                    <h3>ローカルブランチ強制削除</h3>
-                    <code>git branch -D [ブランチ名]</code>
-                    <p>マージ未了のブランチを強制削除</p>
-                </div>
-                <div class="command-card">
-                    <h3>リモートURL変更</h3>
-                    <code>git remote set-url [名前] [新しいURL]</code>
-                    <p>既存リモートのURLを変更</p>
-                </div>
-                <div class="command-card">
-                    <h3>ワークフロー実行</h3>
-                    <code>gh workflow run [名前]</code>
-                    <p>GitHub Actionsを実行</p>
-                </div>
-                <div class="command-card">
-                    <h3>アセットプリコンパイル</h3>
-                    <code>rails assets:precompile</code>
-                    <p>アセットをコンパイル</p>
-                </div>
-                <div class="command-card">
-                    <h3>キャッシュクリア</h3>
-                    <code>rails tmp:clear</code>
-                    <p>一時ファイルをクリア</p>
-                </div>
-                <div class="command-card">
-                    <h3>配列の要素数取得</h3>
-                    <code>array.length</code>
-                    <p>配列の要素数を取得</p>
-                </div>
-                <div class="command-card">
-                    <h3>配列への要素追加</h3>
-                    <code>array.push(element)</code>
-                    <p>配列の末尾に要素を追加</p>
-                </div>
-                <div class="command-card">
-                    <h3>配列から要素削除</h3>
-                    <code>array.pop</code>
-                    <p>配列の末尾から要素を削除</p>
-                </div>
-                <div class="command-card">
-                    <h3>配列の反復処理</h3>
-                    <code>array.each { |item| ... }</code>
-                    <p>配列の各要素に対して処理を実行</p>
-                </div>
-                <div class="command-card">
-                    <h3>配列のマップ処理</h3>
-                    <code>array.map { |item| ... }</code>
-                    <p>配列を変換して新しい配列を作成</p>
-                </div>
-                <div class="command-card">
-                    <h3>配列のフィルタリング</h3>
-                    <code>array.select { |item| ... }</code>
-                    <p>条件に合う要素だけを抽出</p>
-                </div>
-                <div class="command-card">
-                    <h3>配列のソート</h3>
-                    <code>array.sort</code>
-                    <p>配列を昇順にソート</p>
-                </div>
-                <div class="command-card">
-                    <h3>文字列の長さ取得</h3>
-                    <code>string.length</code>
-                    <p>文字列の文字数を取得</p>
-                </div>
-                <div class="command-card">
-                    <h3>文字列を大文字に</h3>
-                    <code>string.upcase</code>
-                    <p>文字列を大文字に変換</p>
-                </div>
-                <div class="command-card">
-                    <h3>文字列を小文字に</h3>
-                    <code>string.downcase</code>
-                    <p>文字列を小文字に変換</p>
-                </div>
-                <div class="command-card">
-                    <h3>文字列の分割</h3>
-                    <code>string.split(',')</code>
-                    <p>文字列を指定文字で分割</p>
-                </div>
-                <div class="command-card">
-                    <h3>文字列の結合</h3>
-                    <code>array.join(',')</code>
-                    <p>配列を文字列に結合</p>
-                </div>
-                <div class="command-card">
-                    <h3>文字列の置換</h3>
-                    <code>string.gsub('old', 'new')</code>
-                    <p>文字列内の文字を置換</p>
-                </div>
-                <div class="command-card">
-                    <h3>ハッシュのキー取得</h3>
-                    <code>hash.keys</code>
-                    <p>ハッシュのすべてのキーを取得</p>
-                </div>
-                <div class="command-card">
-                    <h3>ハッシュの値取得</h3>
-                    <code>hash.values</code>
-                    <p>ハッシュのすべての値を取得</p>
-                </div>
-                <div class="command-card">
-                    <h3>ハッシュの反復処理</h3>
-                    <code>hash.each { |k, v| ... }</code>
-                    <p>ハッシュの各要素を処理</p>
-                </div>
-                <div class="command-card">
-                    <h3>ファイル読み込み</h3>
-                    <code>File.read('filename')</code>
-                    <p>ファイル全体を読み込み</p>
-                </div>
-                <div class="command-card">
-                    <h3>ファイル書き込み</h3>
-                    <code>File.write('filename', data)</code>
-                    <p>ファイルにデータを書き込み</p>
-                </div>
-                <div class="command-card">
-                    <h3>ディレクトリ存在確認</h3>
-                    <code>Dir.exist?('path')</code>
-                    <p>ディレクトリの存在を確認</p>
-                </div>
-                <div class="command-card">
-                    <h3>時間の取得</h3>
-                    <code>Time.now</code>
-                    <p>現在時刻を取得</p>
-                </div>
-                <div class="command-card">
-                    <h3>クラスの定義</h3>
-                    <code>class ClassName ... end</code>
-                    <p>新しいクラスを定義</p>
-                </div>
-                <div class="command-card">
-                    <h3>メソッドの定義</h3>
-                    <code>def method_name ... end</code>
-                    <p>新しいメソッドを定義</p>
-                </div>
-                <div class="command-card">
-                    <h3>例外処理</h3>
-                    <code>begin ... rescue ... end</code>
-                    <p>エラーをキャッチして処理</p>
-                </div>
-                <div class="command-card">
-                    <h3>条件分岐</h3>
-                    <code>if condition ... else ... end</code>
-                    <p>条件による処理の分岐</p>
-                </div>
-                <div class="command-card">
-                    <h3>Devise - 認証</h3>
-                    <code>gem 'devise'</code>
-                    <p>ユーザー認証機能を提供</p>
-                </div>
-                <div class="command-card">
-                    <h3>Sorcery - 認証</h3>
-                    <code>gem 'sorcery'</code>
-                    <p>シンプルな認証機能を提供</p>
-                </div>
-                <div class="command-card">
-                    <h3>Pundit - 認可</h3>
-                    <code>gem 'pundit'</code>
-                    <p>ポリシーベースの認可管理</p>
-                </div>
-                <div class="command-card">
-                    <h3>CarrierWave - ファイルアップロード</h3>
-                    <code>gem 'carrierwave'</code>
-                    <p>ファイルアップロード機能</p>
-                </div>
-                <div class="command-card">
-                    <h3>Kaminari - ページネーション</h3>
-                    <code>gem 'kaminari'</code>
-                    <p>ページネーション機能を追加</p>
-                </div>
-                <div class="command-card">
-                    <h3>Ransack - 検索</h3>
-                    <code>gem 'ransack'</code>
-                    <p>高度な検索機能を提供</p>
-                </div>
-                <div class="command-card">
-                    <h3>Sidekiq - バックグラウンドジョブ</h3>
-                    <code>gem 'sidekiq'</code>
-                    <p>非同期ジョブ処理</p>
-                </div>
-                <div class="command-card">
-                    <h3>Slim - テンプレート</h3>
-                    <code>gem 'slim-rails'</code>
-                    <p>軽量テンプレート言語</p>
-                </div>
-                <div class="command-card">
-                    <h3>Bootstrap - UI</h3>
-                    <code>gem 'bootstrap'</code>
-                    <p>レスポンシブUIフレームワーク</p>
-                </div>
-                <div class="command-card">
-                    <h3>Draper - デコレーター</h3>
-                    <code>gem 'draper'</code>
-                    <p>ビューロジックの分離</p>
-                </div>
-                <div class="command-card">
-                    <h3>ActiveAdmin - 管理画面</h3>
-                    <code>gem 'activeadmin'</code>
-                    <p>管理画面を簡単に作成</p>
-                </div>
-                <div class="command-card">
-                    <h3>Paperclip - ファイル管理</h3>
-                    <code>gem 'paperclip'</code>
-                    <p>ファイル添付機能</p>
-                </div>
-                <div class="command-card">
-                    <h3>Grape - API</h3>
-                    <code>gem 'grape'</code>
-                    <p>RESTful API構築フレームワーク</p>
-                </div>
-                <div class="command-card">
-                    <h3>JWT - トークン認証</h3>
-                    <code>gem 'jwt'</code>
-                    <p>JSON Web Token認証</p>
-                </div>
-                <div class="command-card">
-                    <h3>Redis - キャッシュ</h3>
-                    <code>gem 'redis'</code>
-                    <p>高速キャッシュストア</p>
-                </div>
-                <div class="command-card">
-                    <h3>Whenever - Cron管理</h3>
-                    <code>gem 'whenever'</code>
-                    <p>Cronジョブの管理</p>
-                </div>
-                <div class="command-card">
-                    <h3>I18n - 国際化</h3>
-                    <code>gem 'rails-i18n'</code>
-                    <p>多言語対応機能</p>
-                </div>
-                <div class="command-card">
-                    <h3>Model - Active Record基本</h3>
-                    <code>class User < ApplicationRecord</code>
-                    <p>データベースとの対話を担当するモデル層</p>
-                </div>
-                <div class="command-card">
-                    <h3>Model - バリデーション</h3>
-                    <code>validates :email, presence: true</code>
-                    <p>データの整合性を保証する検証ルール</p>
-                </div>
-                <div class="command-card">
-                    <h3>Model - アソシエーション</h3>
-                    <code>has_many :posts</code>
-                    <p>モデル間の関連付けを定義</p>
-                </div>
-                <div class="command-card">
-                    <h3>Model - スコープ</h3>
-                    <code>scope :active, -> { where(active: true) }</code>
-                    <p>よく使うクエリを再利用可能に</p>
-                </div>
-                <div class="command-card">
-                    <h3>Model - コールバック</h3>
-                    <code>before_save :normalize_email</code>
-                    <p>特定のタイミングで処理を実行</p>
-                </div>
-                <div class="command-card">
-                    <h3>Controller - 基本構造</h3>
-                    <code>class UsersController < ApplicationController</code>
-                    <p>リクエストを処理しレスポンスを返す</p>
-                </div>
-                <div class="command-card">
-                    <h3>Controller - RESTfulアクション</h3>
-                    <code>def index; @users = User.all; end</code>
-                    <p>7つの基本アクション(index,show,new,create,edit,update,destroy)</p>
-                </div>
-                <div class="command-card">
-                    <h3>Controller - Strong Parameters</h3>
-                    <code>params.require(:user).permit(:name, :email)</code>
-                    <p>セキュアなパラメータ処理</p>
-                </div>
-                <div class="command-card">
-                    <h3>Controller - フィルター</h3>
-                    <code>before_action :authenticate_user!</code>
-                    <p>アクション実行前後の処理</p>
-                </div>
-                <div class="command-card">
-                    <h3>View - ERBテンプレート</h3>
-                    <code><%= @user.name %></code>
-                    <p>動的なHTMLを生成するテンプレート</p>
-                </div>
-                <div class="command-card">
-                    <h3>View - パーシャル</h3>
-                    <code><%= render 'shared/header' %></code>
-                    <p>ビューの再利用可能な部品</p>
-                </div>
-                <div class="command-card">
-                    <h3>View - ヘルパーメソッド</h3>
-                    <code><%= link_to 'Home', root_path %></code>
-                    <p>ビューで使える便利なメソッド</p>
-                </div>
-                <div class="command-card">
-                    <h3>View - フォームヘルパー</h3>
-                    <code><%= form_with model: @user %></code>
-                    <p>フォーム作成を簡単に</p>
-                </div>
-                <div class="command-card">
-                    <h3>Routes - リソースルート</h3>
-                    <code>resources :users</code>
-                    <p>RESTfulなルーティングを一括定義</p>
-                </div>
-                <div class="command-card">
-                    <h3>Routes - ネストしたルート</h3>
-                    <code>resources :users do\n  resources :posts\nend</code>
-                    <p>階層的なURL構造を定義</p>
-                </div>
-                <div class="command-card">
-                    <h3>Migration - テーブル作成</h3>
-                    <code>create_table :users do |t|</code>
-                    <p>データベーステーブルの作成</p>
-                </div>
-                <div class="command-card">
-                    <h3>Migration - カラム追加</h3>
-                    <code>add_column :users, :age, :integer</code>
-                    <p>既存テーブルにカラムを追加</p>
-                </div>
-                <div class="command-card">
-                    <h3>Migration - インデックス追加</h3>
-                    <code>add_index :users, :email</code>
-                    <p>検索パフォーマンスを向上</p>
-                </div>
-                <div class="command-card">
-                    <h3>Active Record - クエリメソッド</h3>
-                    <code>User.where(active: true).order(:name)</code>
-                    <p>データベースクエリの構築</p>
-                </div>
-                <div class="command-card">
-                    <h3>Active Record - N+1問題対策</h3>
-                    <code>User.includes(:posts)</code>
-                    <p>関連データを効率的に取得</p>
-                </div>
-                <div class="command-card">
-                    <h3>クエリ最適化 - includes</h3>
-                    <code>User.includes(:posts, :comments)</code>
-                    <p>N+1問題を防ぐEager Loading</p>
-                </div>
-                <div class="command-card">
-                    <h3>クエリ最適化 - select</h3>
-                    <code>User.select(:id, :name)</code>
-                    <p>必要なカラムのみ取得</p>
-                </div>
-                <div class="command-card">
-                    <h3>バッチ処理</h3>
-                    <code>User.find_each(batch_size: 1000)</code>
-                    <p>大量データを分割処理</p>
-                </div>
-                <div class="command-card">
-                    <h3>キャッシュ - ページ</h3>
-                    <code>caches_page :index</code>
-                    <p>ページ全体をキャッシュ</p>
-                </div>
-                <div class="command-card">
-                    <h3>キャッシュ - フラグメント</h3>
-                    <code><% cache @user do %></code>
-                    <p>ビューの一部をキャッシュ</p>
-                </div>
-                <div class="command-card">
-                    <h3>キャッシュ - ロシアンドール</h3>
-                    <code>cache [@user, @post]</code>
-                    <p>ネストしたキャッシュ戦略</p>
-                </div>
-                <div class="command-card">
-                    <h3>Redis キャッシュ</h3>
-                    <code>Rails.cache.fetch("key") { ... }</code>
-                    <p>Redisを使った高速キャッシュ</p>
-                </div>
-                <div class="command-card">
-                    <h3>アセット圧縮</h3>
-                    <code>config.assets.js_compressor = :uglifier</code>
-                    <p>JavaScriptファイルを圧縮</p>
-                </div>
-                <div class="command-card">
-                    <h3>画像最適化</h3>
-                    <code>image_tag "photo.jpg", loading: "lazy"</code>
-                    <p>画像の遅延読み込み</p>
-                </div>
-                <div class="command-card">
-                    <h3>カウンターキャッシュ</h3>
-                    <code>counter_cache: true</code>
-                    <p>関連レコード数をキャッシュ</p>
-                </div>
-                <div class="command-card">
-                    <h3>Webpacker最適化</h3>
-                    <code>rails webpacker:compile</code>
-                    <p>本番用にアセットを最適化</p>
-                </div>
-                <div class="command-card">
-                    <h3>Turbo使用</h3>
-                    <code>data: { turbo: true }</code>
-                    <p>SPAのような高速画面遷移</p>
-                </div>
-                <div class="command-card">
-                    <h3>CDN設定</h3>
-                    <code>config.action_controller.asset_host</code>
-                    <p>静的ファイルをCDNから配信</p>
-                </div>
-                <div class="command-card">
-                    <h3>GET - データ取得</h3>
-                    <code>curl -X GET https://api.example.com/users</code>
-                    <p>サーバーからデータを取得。リソースの読み取り専用</p>
-                </div>
-                <div class="command-card">
-                    <h3>POST - データ作成</h3>
-                    <code>curl -X POST -d '{"name":"John"}' https://api.example.com/users</code>
-                    <p>新しいリソースを作成。サーバーにデータを送信</p>
-                </div>
-                <div class="command-card">
-                    <h3>PUT - データ更新（全体）</h3>
-                    <code>curl -X PUT -d '{"name":"Jane"}' https://api.example.com/users/1</code>
-                    <p>既存リソース全体を置き換え。完全な更新</p>
-                </div>
-                <div class="command-card">
-                    <h3>PATCH - データ更新（部分）</h3>
-                    <code>curl -X PATCH -d '{"email":"new@example.com"}' https://api.example.com/users/1</code>
-                    <p>既存リソースの一部を更新。部分的な変更</p>
-                </div>
-                <div class="command-card">
-                    <h3>DELETE - データ削除</h3>
-                    <code>curl -X DELETE https://api.example.com/users/1</code>
-                    <p>指定したリソースを削除。サーバーから完全に削除</p>
-                </div>
-                <div class="command-card">
-                    <h3>HEAD - ヘッダー取得</h3>
-                    <code>curl -I https://api.example.com/users</code>
-                    <p>レスポンスヘッダーのみ取得。ボディなし</p>
-                </div>
-                <div class="command-card">
-                    <h3>OPTIONS - 許可メソッド確認</h3>
-                    <code>curl -X OPTIONS https://api.example.com/users</code>
-                    <p>サーバーがサポートするHTTPメソッドを確認</p>
-                </div>
-                <div class="command-card">
-                    <h3>curl - 基本的なGETリクエスト</h3>
-                    <code>curl https://api.example.com/data</code>
-                    <p>最もシンプルなHTTPリクエスト実行</p>
-                </div>
-                <div class="command-card">
-                    <h3>curl - ヘッダー付きリクエスト</h3>
-                    <code>curl -H "Authorization: Bearer token" https://api.example.com</code>
-                    <p>認証トークンなどのヘッダーを追加</p>
-                </div>
-                <div class="command-card">
-                    <h3>curl - JSONデータ送信</h3>
-                    <code>curl -H "Content-Type: application/json" -d '{"key":"value"}' https://api.example.com</code>
-                    <p>JSON形式でデータを送信</p>
-                </div>
-                <div class="command-card">
-                    <h3>curl - フォームデータ送信</h3>
-                    <code>curl -X POST -F "name=value" -F "file=@path/to/file" https://api.example.com</code>
-                    <p>フォーム形式でデータとファイルを送信</p>
-                </div>
-                <div class="command-card">
-                    <h3>curl - Basic認証</h3>
-                    <code>curl -u username:password https://api.example.com</code>
-                    <p>Basic認証でアクセス</p>
-                </div>
-                <div class="command-card">
-                    <h3>curl - クッキー送信</h3>
-                    <code>curl -b "session=abc123" https://api.example.com</code>
-                    <p>クッキーを含めてリクエスト</p>
-                </div>
-                <div class="command-card">
-                    <h3>curl - クッキー保存</h3>
-                    <code>curl -c cookies.txt https://api.example.com/login</code>
-                    <p>レスポンスのクッキーをファイルに保存</p>
-                </div>
-                <div class="command-card">
-                    <h3>curl - タイムアウト設定</h3>
-                    <code>curl --connect-timeout 10 --max-time 30 https://api.example.com</code>
-                    <p>接続と全体のタイムアウトを設定</p>
-                </div>
-                <div class="command-card">
-                    <h3>curl - リダイレクト追跡</h3>
-                    <code>curl -L https://api.example.com</code>
-                    <p>リダイレクトを自動的に追跡</p>
-                </div>
-                <div class="command-card">
-                    <h3>curl - プロキシ経由</h3>
-                    <code>curl -x http://proxy:8080 https://api.example.com</code>
-                    <p>プロキシサーバー経由でアクセス</p>
-                </div>
-                <div class="command-card">
-                    <h3>curl - SSL証明書検証スキップ</h3>
-                    <code>curl -k https://api.example.com</code>
-                    <p>開発環境でSSL証明書の検証をスキップ</p>
-                </div>
-                <div class="command-card">
-                    <h3>curl - レスポンスを整形</h3>
-                    <code>curl https://api.example.com/data | jq</code>
-                    <p>JSONレスポンスを見やすく整形</p>
-                </div>
-                <div class="command-card">
-                    <h3>curl - ファイルダウンロード</h3>
-                    <code>curl -O https://example.com/file.pdf</code>
-                    <p>ファイルをダウンロードして保存</p>
-                </div>
-                <div class="command-card">
-                    <h3>curl - 詳細情報表示</h3>
-                    <code>curl -v https://api.example.com</code>
-                    <p>リクエスト/レスポンスの詳細を表示</p>
-                </div>
-                <div class="command-card">
-                    <h3>curl - 静かモード</h3>
-                    <code>curl -s https://api.example.com</code>
-                    <p>進捗バーなどを非表示にして実行</p>
-                </div>
-                <div class="command-card">
-                    <h3>HTTPie - GET</h3>
-                    <code>http GET api.example.com/users</code>
-                    <p>HTTPieを使った見やすいGETリクエスト</p>
-                </div>
-                <div class="command-card">
-                    <h3>HTTPie - POST</h3>
-                    <code>http POST api.example.com/users name="John" age=30</code>
-                    <p>HTTPieでJSON形式のPOSTリクエスト</p>
-                </div>
-                <div class="command-card">
-                    <h3>wget - ファイル取得</h3>
-                    <code>wget https://example.com/file.zip</code>
-                    <p>ファイルをダウンロード</p>
-                </div>
-                <div class="command-card">
-                    <h3>wget - 再帰的ダウンロード</h3>
-                    <code>wget -r https://example.com/docs/</code>
-                    <p>ディレクトリ全体を再帰的にダウンロード</p>
-                </div>
-                <div class="command-card">
-                    <h3>Rails - HTTPリクエスト（Net::HTTP）</h3>
-                    <code>Net::HTTP.get(URI('https://api.example.com/data'))</code>
-                    <p>RubyのNet::HTTPライブラリでGETリクエスト</p>
-                </div>
-                <div class="command-card">
-                    <h3>Rails - HTTParty gem</h3>
-                    <code>HTTParty.get('https://api.example.com/users')</code>
-                    <p>HTTParty gemを使った簡単なHTTPリクエスト</p>
-                </div>
-                <div class="command-card">
-                    <h3>Rails - Faraday gem</h3>
-                    <code>Faraday.get('https://api.example.com/data')</code>
-                    <p>Faraday gemでHTTPリクエスト</p>
-                </div>
-                <div class="command-card">
-                    <h3>Rails - RestClient gem</h3>
-                    <code>RestClient.get 'https://api.example.com/users'</code>
-                    <p>RestClient gemでシンプルなAPI呼び出し</p>
-                </div>
-                <div class="command-card">
-                    <h3>Rails - API認証付きリクエスト</h3>
-                    <code>HTTParty.get(url, headers: { 'Authorization' => "Bearer #{token}" })</code>
-                    <p>認証トークン付きのAPIリクエスト</p>
-                </div>
-                <div class="command-card">
-                    <h3>ステータスコード - 200 OK</h3>
-                    <code>HTTP/1.1 200 OK</code>
-                    <p>リクエスト成功。正常にデータを返す</p>
-                </div>
-                <div class="command-card">
-                    <h3>ステータスコード - 201 Created</h3>
-                    <code>HTTP/1.1 201 Created</code>
-                    <p>新しいリソースの作成成功</p>
-                </div>
-                <div class="command-card">
-                    <h3>ステータスコード - 204 No Content</h3>
-                    <code>HTTP/1.1 204 No Content</code>
-                    <p>成功したが返すコンテンツなし</p>
-                </div>
-                <div class="command-card">
-                    <h3>ステータスコード - 400 Bad Request</h3>
-                    <code>HTTP/1.1 400 Bad Request</code>
-                    <p>不正なリクエスト。パラメータエラー</p>
-                </div>
-                <div class="command-card">
-                    <h3>ステータスコード - 401 Unauthorized</h3>
-                    <code>HTTP/1.1 401 Unauthorized</code>
-                    <p>認証が必要。認証情報なしまたは無効</p>
-                </div>
-                <div class="command-card">
-                    <h3>ステータスコード - 403 Forbidden</h3>
-                    <code>HTTP/1.1 403 Forbidden</code>
-                    <p>アクセス禁止。権限不足</p>
-                </div>
-                <div class="command-card">
-                    <h3>ステータスコード - 404 Not Found</h3>
-                    <code>HTTP/1.1 404 Not Found</code>
-                    <p>リソースが見つからない</p>
-                </div>
-                <div class="command-card">
-                    <h3>ステータスコード - 422 Unprocessable Entity</h3>
-                    <code>HTTP/1.1 422 Unprocessable Entity</code>
-                    <p>検証エラー。データは正しいが処理できない</p>
-                </div>
-                <div class="command-card">
-                    <h3>ステータスコード - 500 Internal Server Error</h3>
-                    <code>HTTP/1.1 500 Internal Server Error</code>
-                    <p>サーバー内部エラー</p>
-                </div>
-                <div class="command-card">
-                    <h3>ステータスコード - 502 Bad Gateway</h3>
-                    <code>HTTP/1.1 502 Bad Gateway</code>
-                    <p>ゲートウェイまたはプロキシのエラー</p>
-                </div>
-                <div class="command-card">
-                    <h3>ステータスコード - 503 Service Unavailable</h3>
-                    <code>HTTP/1.1 503 Service Unavailable</code>
-                    <p>サービス利用不可。メンテナンス中など</p>
-                </div>
+                <div class="command-card" id="cmd-gem-list">
+                    <h3>インストール済み一覧</h3>
+                    <code>gem list</code>
+                    <p>インストール済みGemの一覧</p>
+                </div>
+                <div class="command-card" id="cmd-gem-update">
+                    <h3>Gemの更新</h3>
+                    <code>gem update [gem名]</code>
+                    <p>特定のGemを最新版に更新</p>
+                </div>
+                <div class="command-card" id="cmd-bundle-install">
+                    <h3>Bundlerでインストール</h3>
+                    <code>bundle install</code>
+                    <p>Gemfileに記載のGemをインストール</p>
+                </div>
+                <div class="command-card" id="cmd-bundle-update">
+                    <h3>Bundle更新</h3>
+                    <code>bundle update</code>
+                    <p>すべてのGemを更新</p>
+                </div>
+                <div class="command-card" id="cmd-gem-info">
+                    <h3>Gemの情報表示</h3>
+                    <code>gem info [gem名]</code>
+                    <p>Gemの詳細情報を表示</p>
+                </div>
+                <div class="command-card" id="cmd-gem-search">
+                    <h3>Gemを検索</h3>
+                    <code>gem search [キーワード]</code>
+                    <p>リポジトリからGemを検索</p>
+                </div>
+            </div>
+        </section>
+
+        <section id="linux" class="category">
+            <h2 style="border-bottom: 2px solid #ddd; padding-bottom: 10px; margin-top: 40px;">🐧 Linux リファレンス</h2>
+            <div class="commands-grid">
+                <div class="command-card" id="cmd-ls"><h3>ディレクトリ内容表示</h3><code>ls</code><p>現在のディレクトリのファイル一覧</p></div>
+                <div class="command-card" id="cmd-ls-la"><h3>詳細表示</h3><code>ls -la</code><p>隠しファイルを含む詳細情報</p></div>
+                <div class="command-card" id="cmd-cd"><h3>ディレクトリ移動</h3><code>cd [ディレクトリ名]</code><p>指定ディレクトリへ移動</p></div>
+                <div class="command-card" id="cmd-pwd"><h3>現在地表示</h3><code>pwd</code><p>現在のディレクトリパスを表示</p></div>
+                <div class="command-card" id="cmd-mkdir"><h3>ディレクトリ作成</h3><code>mkdir [ディレクトリ名]</code><p>新しいディレクトリを作成</p></div>
+                <div class="command-card" id="cmd-rm"><h3>ファイル削除</h3><code>rm [ファイル名]</code><p>ファイルを削除</p></div>
+                <div class="command-card" id="cmd-rm-rf"><h3>ディレクトリ削除</h3><code>rm -rf [ディレクトリ名]</code><p>ディレクトリを強制削除</p></div>
+                <div class="command-card" id="cmd-cp"><h3>ファイルコピー</h3><code>cp [元] [先]</code><p>ファイルをコピー</p></div>
+                <div class="command-card" id="cmd-mv"><h3>ファイル移動</h3><code>mv [元] [先]</code><p>ファイルを移動または名前変更</p></div>
+                <div class="command-card" id="cmd-cat"><h3>ファイル内容表示</h3><code>cat [ファイル名]</code><p>ファイルの内容を表示</p></div>
+                <div class="command-card" id="cmd-find"><h3>ファイル検索</h3><code>find . -name "[ファイル名]"</code><p>ファイルを名前で検索</p></div>
+                <div class="command-card" id="cmd-grep"><h3>テキスト検索</h3><code>grep "[検索文字]" [ファイル]</code><p>ファイル内のテキストを検索</p></div>
+                <div class="command-card" id="cmd-chmod"><h3>権限変更</h3><code>chmod 755 [ファイル名]</code><p>ファイルの権限を変更</p></div>
+                <div class="command-card" id="cmd-ps-aux"><h3>プロセス表示</h3><code>ps aux</code><p>実行中のプロセス一覧</p></div>
+                <div class="command-card" id="cmd-diff"><h3>差分表示</h3><code>diff [ファイル1] [ファイル2]</code><p>2つのファイル間の差分を表示</p></div>
+                <div class="command-card" id="cmd-touch"><h3>空ファイル作成</h3><code>touch [ファイル名]</code><p>ファイルのタイムスタンプを更新、または空ファイルを作成</p></div>
+                <div class="command-card" id="cmd-rmdir"><h3>空ディレクトリ削除</h3><code>rmdir [ディレクトリ名]</code><p>中身が空のディレクトリを削除</p></div>
+                <div class="command-card" id="cmd-head"><h3>ファイル先頭表示</h3><code>head [ファイル名]</code><p>ファイルの先頭部分を表示</p></div>
+                <div class="command-card" id="cmd-tail"><h3>ファイル末尾表示</h3><code>tail [ファイル名]</code><p>ファイルの末尾部分を表示</p></div>
+                <div class="command-card" id="cmd-wc"><h3>単語・行数カウント</h3><code>wc [ファイル名]</code><p>ファイル内の行数、単語数、バイト数をカウント</p></div>
+                <div class="command-card" id="cmd-sort"><h3>テキストソート</h3><code>sort [ファイル名]</code><p>テキストファイルの行をソート</p></div>
+                <div class="command-card" id="cmd-uniq"><h3>重複行の削除</h3><code>uniq [ファイル名]</code><p>ソート済みファイルから重複する行を削除</p></div>
+                <div class="command-card" id="cmd-chown"><h3>所有者変更</h3><code>chown [所有者] [ファイル]</code><p>ファイルやディレクトリの所有者を変更</p></div>
+                <div class="command-card" id="cmd-tar"><h3>アーカイブ作成</h3><code>tar -cvf [archive.tar] [ファイル]</code><p>複数のファイルを一つのアーカイブにまとめる</p></div>
+                <div class="command-card" id="cmd-gzip"><h3>ファイル圧縮</h3><code>gzip [ファイル名]</code><p>ファイルを圧縮（.gz）</p></div>
+                <div class="command-card" id="cmd-kill"><h3>プロセス終了</h3><code>kill [プロセスID]</code><p>指定したプロセスを終了させる</p></div>
+                <div class="command-card" id="cmd-echo"><h3>テキスト出力</h3><code>echo "テキスト"</code><p>指定した文字列や変数の内容を標準出力に表示</p></div>
+                <div class="command-card" id="cmd-export"><h3>環境変数設定</h3><code>export VAR=value</code><p>環境変数を設定またはエクスポート</p></div>
+                <div class="command-card" id="cmd-alias"><h3>エイリアス設定</h3><code>alias name='command'</code><p>コマンドの別名を定義</p></div>
+                <div class="command-card" id="cmd-history"><h3>コマンド履歴</h3><code>history</code><p>実行したコマンドの履歴を表示</p></div>
+                <div class="command-card" id="cmd-man"><h3>マニュアル表示</h3><code>man [コマンド]</code><p>コマンドのマニュアルページを表示</p></div>
+                <div class="command-card" id="cmd-which"><h3>コマンドパス表示</h3><code>which [コマンド]</code><p>コマンドの実行ファイルの場所を特定</p></div>
+                <div class="command-card" id="cmd-date"><h3>日時表示</h3><code>date</code><p>現在の日付と時刻を表示</p></div>
+                <div class="command-card" id="cmd-who"><h3>ログインユーザー表示</h3><code>who</code><p>現在システムにログインしているユーザーの一覧を表示</p></div>
+                <div class="command-card" id="cmd-df-h"><h3>ディスク使用量</h3><code>df -h</code><p>ディスクの空き容量と使用状況を表示</p></div>
+                <div class="command-card" id="cmd-du-h"><h3>ファイルサイズ表示</h3><code>du -h [ファイル/ディレクトリ]</code><p>ファイルやディレクトリのディスク使用量を表示</p></div>
+                <div class="command-card" id="cmd-mount"><h3>ファイルシステムのマウント</h3><code>mount</code><p>ファイルシステムをマウント（接続）する</p></div>
+                <div class="command-card" id="cmd-umount"><h3>アンマウント</h3><code>umount [デバイス]</code><p>マウントされたファイルシステムを解除</p></div>
+                <div class="command-card" id="cmd-ln-s"><h3>シンボリックリンク作成</h3><code>ln -s [元] [リンク名]</code><p>ファイルやディレクトリへのシンボリックリンクを作成</p></div>
+                <div class="command-card" id="cmd-sed"><h3>ストリームエディタ</h3><code>sed 's/old/new/g' [ファイル]</code><p>テキストの置換や削除などの編集を行う</p></div>
+                <div class="command-card" id="cmd-awk"><h3>テキスト処理</h3><code>awk '{print $1}' [ファイル]</code><p>テキストを行ごとに処理する強力なプログラミング言語</p></div>
+                <div class="command-card" id="cmd-cut"><h3>フィールド抽出</h3><code>cut -f1 -d',' [ファイル]</code><p>テキストの各行からフィールドを抽出</p></div>
+            </div>
+        </section>
+        <section id="git" class="category">
+            <h2 style="border-bottom: 2px solid #ddd; padding-bottom: 10px; margin-top: 40px;">📦 Git リファレンス</h2>
+            <div class="commands-grid">
+                <div class="command-card" id="cmd-git-init"><h3>リポジトリ初期化</h3><code>git init</code><p>新しいGitリポジトリを作成</p></div>
+                <div class="command-card" id="cmd-git-init-dir"><h3>特定ディレクトリで初期化</h3><code>git init /tmp/example</code><p>指定したディレクトリに新しいGitリポジトリを作成</p></div>
+                <div class="command-card" id="cmd-git-clone"><h3>クローン</h3><code>git clone [URL]</code><p>リモートリポジトリをコピー</p></div>
+                <div class="command-card" id="cmd-git-status"><h3>ステータス確認</h3><code>git status</code><p>変更状況を確認</p></div>
+                <div class="command-card" id="cmd-git-add-dot"><h3>ファイル追加</h3><code>git add .</code><p>すべての変更をステージング</p></div>
+                <div class="command-card" id="cmd-git-commit-m"><h3>コミット</h3><code>git commit -m "メッセージ"</code><p>変更を記録</p></div>
+                <div class="command-card" id="cmd-git-push"><h3>プッシュ</h3><code>git push origin main</code><p>リモートに送信</p></div>
+                <div class="command-card" id="cmd-git-pull"><h3>プル</h3><code>git pull</code><p>リモートから取得</p></div>
+                <div class="command-card" id="cmd-git-branch"><h3>ブランチ一覧</h3><code>git branch</code><p>ブランチの一覧表示</p></div>
+                <div class="command-card" id="cmd-git-checkout-b"><h3>ブランチ作成・切替</h3><code>git checkout -b [ブランチ名]</code><p>新しいブランチを作成して切替</p></div>
+                <div class="command-card" id="cmd-git-merge"><h3>マージ</h3><code>git merge [ブランチ名]</code><p>ブランチを統合</p></div>
+                <div class="command-card" id="cmd-git-log-oneline"><h3>ログ表示</h3><code>git log --oneline</code><p>コミット履歴を一行表示</p></div>
+                <div class="command-card" id="cmd-git-diff"><h3>差分表示</h3><code>git diff</code><p>変更内容を表示</p></div>
+                <div class="command-card" id="cmd-git-reset-hard"><h3>取り消し</h3><code>git reset --hard HEAD</code><p>すべての変更を取り消し</p></div>
+                <div class="command-card" id="cmd-git-stash"><h3>スタッシュ</h3><code>git stash</code><p>変更を一時保存</p></div>
+                <div class="command-card" id="cmd-git-fetch"><h3>フェッチ</h3><code>git fetch</code><p>リモートから最新情報を取得（マージなし）</p></div>
+                <div class="command-card" id="cmd-git-checkout"><h3>ブランチ切替</h3><code>git checkout [ブランチ名]</code><p>既存のブランチに切り替え</p></div>
+                <div class="command-card" id="cmd-git-rebase"><h3>リベース</h3><code>git rebase [ブランチ名]</code><p>ブランチをリベース</p></div>
+                <div class="command-card" id="cmd-git-remote-v"><h3>リモートリポジトリ確認</h3><code>git remote -v</code><p>リモートリポジトリの一覧表示</p></div>
+                <div class="command-card" id="cmd-git-stash-pop"><h3>スタッシュの適用</h3><code>git stash pop</code><p>一時保存した変更を復元</p></div>
+                <div class="command-card" id="cmd-git-log"><h3>ログ詳細表示</h3><code>git log</code><p>コミット履歴を詳細表示</p></div>
+                <div class="command-card" id="cmd-git-remote-add"><h3>リモートリポジトリ追加</h3><code>git remote add [名前] [URL]</code><p>新しいリモートリポジトリを登録</p></div>
+                <div class="command-card" id="cmd-git-remote-set-url"><h3>リモートURL変更</h3><code>git remote set-url [名前] [新しいURL]</code><p>既存リモートのURLを変更</p></div>
+                <div class="command-card" id="cmd-git-push-branch"><h3>ブランチをプッシュ</h3><code>git push [リモート名] [ブランチ名]</code><p>指定したブランチをリモートにプッシュ</p></div>
+                <div class="command-card" id="cmd-git-pull-branch"><h3>ブランチをプル</h3><code>git pull [リモート名] [ブランチ名]</code><p>指定したブランチをリモートからプル</p></div>
+                <div class="command-card" id="cmd-git-branch-d"><h3>ローカルブランチ削除</h3><code>git branch -d [ブランチ名]</code><p>マージ済みのローカルブランチを削除</p></div>
+                <div class="command-card" id="cmd-git-branch-D"><h3>ローカルブランチ強制削除</h3><code>git branch -D [ブランチ名]</code><p>マージ未了のブランチを強制削除</p></div>
+                <div class="command-card" id="cmd-git-push-delete"><h3>リモートブランチ削除</h3><code>git push origin --delete [ブランチ名]</code><p>リモートリポジトリのブランチを削除</p></div>
+                <div class="command-card" id="cmd-git-branch-a"><h3>全ブランチ一覧</h3><code>git branch -a</code><p>リモートを含む全ブランチを表示</p></div>
+                <div class="command-card" id="cmd-git-branch-new"><h3>ブランチ作成</h3><code>git branch [ブランチ名]</code><p>新しいブランチを作成（切替はなし）</p></div>
+                <div class="command-card" id="cmd-git-add-file"><h3>特定ファイル追加</h3><code>git add [ファイル名]</code><p>指定したファイルのみステージング</p></div>
+                <div class="command-card" id="cmd-git-log-graph"><h3>グラフ形式ログ</h3><code>git log --oneline --graph</code><p>履歴をグラフ形式で一行表示</p></div>
+                <div class="command-card" id="cmd-git-reset"><h3>コミットまで戻す</h3><code>git reset [コミット]</code><p>指定コミットまで変更を戻す（--soft, --mixed, --hard）</p></div>
+                <div class="command-card" id="cmd-git-revert"><h3>コミット打ち消し</h3><code>git revert [コミット]</code><p>指定コミットの変更を打ち消すコミットを作成</p></div>
+                <div class="command-card" id="cmd-git-commit-amend"><h3>直前コミット修正</h3><code>git commit --amend</code><p>直前のコミットを修正（メッセージやファイル追加）</p></div>
+                <div class="command-card" id="cmd-git-stash-list"><h3>スタッシュ一覧</h3><code>git stash list</code><p>一時保存した変更の一覧を表示</p></div>
+                <div class="command-card" id="cmd-git-cherry-pick"><h3>コミット取り込み</h3><code>git cherry-pick [コミットID]</code><p>別のブランチから特定のコミットを取り込む</p></div>
+                <div class="command-card" id="cmd-git-tag"><h3>タグ付け</h3><code>git tag [タグ名]</code><p>特定のコミットにバージョン等のタグを付ける</p></div>
+                <div class="command-card" id="cmd-git-push-tag"><h3>タグをプッシュ</h3><code>git push origin [タグ名]</code><p>作成したタグをリモートに送信</p></div>
+                <div class="command-card" id="cmd-git-ls-files"><h3>管理ファイル一覧</h3><code>git ls-files</code><p>Gitが管理しているファイルの一覧を表示</p></div>
+                <div class="command-card" id="cmd-git-rm"><h3>ファイル削除</h3><code>git rm [ファイル名]</code><p>ファイルをリポジトリとワーキングツリーから削除</p></div>
+                <div class="command-card" id="cmd-git-mv"><h3>ファイル移動</h3><code>git mv [元] [先]</code><p>ファイルの移動またはリネームを記録</p></div>
+                <div class="command-card" id="cmd-git-grep"><h3>リポジトリ内検索</h3><code>git grep [パターン]</code><p>管理下のファイルから指定パターンを検索</p></div>
+                <div class="command-card" id="cmd-git-show"><h3>オブジェクト内容表示</h3><code>git show [コミット/タグ]</code><p>コミットやタグなどのオブジェクト情報を表示</p></div>
+                <div class="command-card" id="cmd-git-rev-parse"><h3>リポジトリルート表示</h3><code>git rev-parse --show-toplevel</code><p>リポジトリのトップレベルディレクトリのパスを表示</p></div>
+                <div class="command-card" id="cmd-git-log-grep"><h3>コミットメッセージ検索</h3><code>git log --grep="[パターン]"</code><p>コミットメッセージからパターンを検索</p></div>
+                <div class="command-card" id="cmd-git-log-n"><h3>最新コミット表示</h3><code>git log -n [数]</code><p>指定した数だけ最新のコミットを表示</p></div>
+                <div class="command-card" id="cmd-git-log-reverse"><h3>古い順にログ表示</h3><code>git log --reverse</code><p>コミット履歴を古いものから順に表示</p></div>
+                <div class="command-card" id="cmd-git-shortlog-sn"><h3>コミット数統計</h3><code>git shortlog -sn</code><p>コントリビューター毎のコミット数を集計して表示</p></div>
+                <div class="command-card" id="cmd-git-log-date-order"><h3>日付順ログ</h3><code>git log --date-order</code><p>コミットを日付順にソートして表示</p></div>
+                <div class="command-card" id="cmd-git-log-no-merges"><h3>マージコミット除外</h3><code>git log --no-merges</code><p>マージコミットをログ表示から除外</p></div>
+                <div class="command-card" id="cmd-git-update-index"><h3>実行権限変更</h3><code>git update-index --chmod=+x [ファイル]</code><p>ファイルの実行権限をGitに記録</p></div>
+                <div class="command-card" id="cmd-git-config-user"><h3>ユーザー名設定</h3><code>git config user.name "名前"</code><p>コミットに使用するユーザー名を設定</p></div>
+                <div class="command-card" id="cmd-git-archive"><h3>アーカイブ作成</h3><code>git archive --format=zip HEAD -o file.zip</code><p>リポジトリの内容をzipなどのアーカイブ形式で出力</p></div>
+                <div class="command-card" id="cmd-git-gc"><h3>リポジトリ最適化</h3><code>git gc</code><p>不要なオブジェクトを削除しリポジトリを最適化</p></div>
+                <div class="command-card" id="cmd-git-config-global"><h3>グローバル設定</h3><code>git config --global user.name "名前"</code><p>システム全体に適用されるGit設定を行う</p></div>
+                <div class="command-card" id="cmd-git-config-alias"><h3>エイリアス設定</h3><code>git config --global alias.st status</code><p>Gitコマンドの短縮形（エイリアス）を設定</p></div>
+                <div class="command-card" id="cmd-git-reflog"><h3>参照履歴表示</h3><code>git reflog</code><p>HEADやブランチの移動履歴を表示</p></div>
+                <div class="command-card" id="cmd-git-help"><h3>ヘルプ表示</h3><code>git help [コマンド]</code><p>指定したGitコマンドのヘルプドキュメントを表示</p></div>
+                <div class="command-card" id="cmd-git-exec-path"><h3>実行パス表示</h3><code>git --exec-path</code><p>Gitの内部コマンドが配置されているパスを表示</p></div>
+                <div class="command-card" id="cmd-git-log-date"><h3>日付指定ログ</h3><code>git log --date=iso</code><p>ログの日付フォーマットを指定して表示</p></div>
+                <div class="command-card" id="cmd-git-shortlog"><h3>コントリビューター表示</h3><code>git shortlog</code><p>コントリビューターのコミット概要を表示</p></div>
+                <div class="command-card" id="cmd-git-count-objects"><h3>オブジェクト数表示</h3><code>git count-objects -v</code><p>リポジトリ内のオブジェクト数やサイズを表示</p></div>
+                <div class="command-card" id="cmd-git-gc-aggressive"><h3>強力な最適化</h3><code>git gc --aggressive</code><p>より強力なリポジトリの最適化を実行</p></div>
+                <div class="command-card" id="cmd-git-remote-remove"><h3>リモートリポジトリ削除</h3><code>git remote remove [名前]</code><p>登録されているリモートリポジトリを削除</p></div>
+                <div class="command-card" id="cmd-git-filter-branch"><h3>履歴の書き換え</h3><code>git filter-branch --tree-filter 'rm -f passwords.txt' HEAD</code><p>全コミット履歴に対してスクリプトを実行し履歴を書き換え</p></div>
+                <div class="command-card" id="cmd-git-log-format"><h3>ログフォーマット指定</h3><code>git log --format="%h - %an, %ar : %s"</code><p>ログの出力フォーマットをカスタマイズ</p></div>
+            </div>
+        </section>
+        <section id="github" class="category">
+            <h2 style="border-bottom: 2px solid #ddd; padding-bottom: 10px; margin-top: 40px;">🐙 GitHub リファレンス</h2>
+            <div class="commands-grid">
+                <div class="command-card" id="cmd-gh-auth-login"><h3>認証</h3><code>gh auth login</code><p>GitHubにログイン</p></div>
+                <div class="command-card" id="cmd-gh-repo-create"><h3>リポジトリ作成</h3><code>gh repo create [名前]</code><p>新しいリポジトリを作成</p></div>
+                <div class="command-card" id="cmd-gh-repo-clone"><h3>リポジトリクローン</h3><code>gh repo clone [リポジトリ]</code><p>リポジトリをクローン</p></div>
+                <div class="command-card" id="cmd-gh-pr-create"><h3>PR作成</h3><code>gh pr create</code><p>プルリクエストを作成</p></div>
+                <div class="command-card" id="cmd-gh-pr-list"><h3>PR一覧</h3><code>gh pr list</code><p>プルリクエスト一覧</p></div>
+                <div class="command-card" id="cmd-gh-issue-create"><h3>Issue作成</h3><code>gh issue create</code><p>新しいIssueを作成</p></div>
+                <div class="command-card" id="cmd-gh-issue-list"><h3>Issue一覧</h3><code>gh issue list</code><p>Issue一覧を表示</p></div>
+                <div class="command-card" id="cmd-gh-workflow-run"><h3>ワークフロー実行</h3><code>gh workflow run [名前]</code><p>GitHub Actionsを実行</p></div>
+            </div>
+        </section>
+        <section id="rails" class="category">
+            <h2 style="border-bottom: 2px solid #ddd; padding-bottom: 10px; margin-top: 40px;">🛤️ Rails リファレンス</h2>
+            <div class="commands-grid">
+                <div class="command-card" id="cmd-rails-new"><h3>新規アプリ作成</h3><code>rails new [アプリ名]</code><p>新しいRailsアプリを作成</p></div>
+                <div class="command-card" id="cmd-rails-server"><h3>サーバー起動</h3><code>rails server</code><p>開発サーバーを起動</p></div>
+                <div class="command-card" id="cmd-rails-console"><h3>コンソール起動</h3><code>rails console</code><p>Railsコンソールを起動</p></div>
+                <div class="command-card" id="cmd-rails-db-create"><h3>DB作成</h3><code>rails db:create</code><p>データベースを作成</p></div>
+                <div class="command-card" id="cmd-rails-db-migrate"><h3>マイグレーション実行</h3><code>rails db:migrate</code><p>DBマイグレーションを実行</p></div>
+                <div class="command-card" id="cmd-rails-db-rollback"><h3>ロールバック</h3><code>rails db:rollback</code><p>マイグレーションを戻す</p></div>
+                <div class="command-card" id="cmd-rails-db-seed"><h3>シード実行</h3><code>rails db:seed</code><p>初期データを投入</p></div>
+                <div class="command-card" id="cmd-rails-g-model"><h3>モデル生成</h3><code>rails g model [モデル名]</code><p>新しいモデルを生成</p></div>
+                <div class="command-card" id="cmd-rails-g-controller"><h3>コントローラー生成</h3><code>rails g controller [名前]</code><p>新しいコントローラーを生成</p></div>
+                <div class="command-card" id="cmd-rails-g-scaffold"><h3>Scaffold生成</h3><code>rails g scaffold [名前]</code><p>CRUD機能を一括生成</p></div>
+                <div class="command-card" id="cmd-rails-routes"><h3>ルート確認</h3><code>rails routes</code><p>ルーティング一覧を表示</p></div>
+                <div class="command-card" id="cmd-rails-test"><h3>テスト実行</h3><code>rails test</code><p>テストスイートを実行</p></div>
+                <div class="command-card" id="cmd-rails-assets-precompile"><h3>アセットプリコンパイル</h3><code>rails assets:precompile</code><p>アセットをコンパイル</p></div>
+                <div class="command-card" id="cmd-rails-tmp-clear"><h3>キャッシュクリア</h3><code>rails tmp:clear</code><p>一時ファイルをクリア</p></div>
+            </div>
+        </section>
+        <section id="ruby" class="category">
+            <h2 style="border-bottom: 2px solid #ddd; padding-bottom: 10px; margin-top: 40px;">💎 Ruby リファレンス</h2>
+            <div class="commands-grid">
+                <div class="command-card" id="cmd-ruby-array-length"><h3>配列の要素数取得</h3><code>array.length</code><p>配列の要素数を取得</p></div>
+                <div class="command-card" id="cmd-ruby-array-push"><h3>配列への要素追加</h3><code>array.push(element)</code><p>配列の末尾に要素を追加</p></div>
+                <div class="command-card" id="cmd-ruby-array-pop"><h3>配列から要素削除</h3><code>array.pop</code><p>配列の末尾から要素を削除</p></div>
+                <div class="command-card" id="cmd-ruby-array-each"><h3>配列の反復処理</h3><code>array.each { |item| ... }</code><p>配列の各要素に対して処理を実行</p></div>
+                <div class="command-card" id="cmd-ruby-array-map"><h3>配列のマップ処理</h3><code>array.map { |item| ... }</code><p>配列を変換して新しい配列を作成</p></div>
+                <div class="command-card" id="cmd-ruby-array-select"><h3>配列のフィルタリング</h3><code>array.select { |item| ... }</code><p>条件に合う要素だけを抽出</p></div>
+                <div class="command-card" id="cmd-ruby-array-sort"><h3>配列のソート</h3><code>array.sort</code><p>配列を昇順にソート</p></div>
+                <div class="command-card" id="cmd-ruby-string-length"><h3>文字列の長さ取得</h3><code>string.length</code><p>文字列の文字数を取得</p></div>
+                <div class="command-card" id="cmd-ruby-string-upcase"><h3>文字列を大文字に</h3><code>string.upcase</code><p>文字列を大文字に変換</p></div>
+                <div class="command-card" id="cmd-ruby-string-downcase"><h3>文字列を小文字に</h3><code>string.downcase</code><p>文字列を小文字に変換</p></div>
+                <div class="command-card" id="cmd-ruby-string-split"><h3>文字列の分割</h3><code>string.split(',')</code><p>文字列を指定文字で分割</p></div>
+                <div class="command-card" id="cmd-ruby-array-join"><h3>文字列の結合</h3><code>array.join(',')</code><p>配列を文字列に結合</p></div>
+                <div class="command-card" id="cmd-ruby-string-gsub"><h3>文字列の置換</h3><code>string.gsub('old', 'new')</code><p>文字列内の文字を置換</p></div>
+                <div class="command-card" id="cmd-ruby-hash-keys"><h3>ハッシュのキー取得</h3><code>hash.keys</code><p>ハッシュのすべてのキーを取得</p></div>
+                <div class="command-card" id="cmd-ruby-hash-values"><h3>ハッシュの値取得</h3><code>hash.values</code><p>ハッシュのすべての値を取得</p></div>
+                <div class="command-card" id="cmd-ruby-hash-each"><h3>ハッシュの反復処理</h3><code>hash.each { |k, v| ... }</code><p>ハッシュの各要素を処理</p></div>
+                <div class="command-card" id="cmd-ruby-file-read"><h3>ファイル読み込み</h3><code>File.read('filename')</code><p>ファイル全体を読み込み</p></div>
+                <div class="command-card" id="cmd-ruby-file-write"><h3>ファイル書き込み</h3><code>File.write('filename', data)</code><p>ファイルにデータを書き込み</p></div>
+                <div class="command-card" id="cmd-ruby-dir-exist"><h3>ディレクトリ存在確認</h3><code>Dir.exist?('path')</code><p>ディレクトリの存在を確認</p></div>
+                <div class="command-card" id="cmd-ruby-time-now"><h3>時間の取得</h3><code>Time.now</code><p>現在時刻を取得</p></div>
+                <div class="command-card" id="cmd-ruby-class"><h3>クラスの定義</h3><code>class ClassName ... end</code><p>新しいクラスを定義</p></div>
+                <div class="command-card" id="cmd-ruby-def"><h3>メソッドの定義</h3><code>def method_name ... end</code><p>新しいメソッドを定義</p></div>
+                <div class="command-card" id="cmd-ruby-begin-rescue"><h3>例外処理</h3><code>begin ... rescue ... end</code><p>エラーをキャッチして処理</p></div>
+                <div class="command-card" id="cmd-ruby-if"><h3>条件分岐</h3><code>if condition ... else ... end</code><p>条件による処理の分岐</p></div>
+            </div>
+        </section>
+        <section id="gem-library" class="category">
+            <h2 style="border-bottom: 2px solid #ddd; padding-bottom: 10px; margin-top: 40px;">📚 Gem Libraryリファレンス</h2>
+            <div class="commands-grid">
+                <div class="command-card" id="cmd-gem-devise"><h3>Devise - 認証</h3><code>gem 'devise'</code><p>ユーザー認証機能を提供</p></div>
+                <div class="command-card" id="cmd-gem-sorcery"><h3>Sorcery - 認証</h3><code>gem 'sorcery'</code><p>シンプルな認証機能を提供</p></div>
+                <div class="command-card" id="cmd-gem-pundit"><h3>Pundit - 認可</h3><code>gem 'pundit'</code><p>ポリシーベースの認可管理</p></div>
+                <div class="command-card" id="cmd-gem-carrierwave"><h3>CarrierWave - ファイルアップロード</h3><code>gem 'carrierwave'</code><p>ファイルアップロード機能</p></div>
+                <div class="command-card" id="cmd-gem-kaminari"><h3>Kaminari - ページネーション</h3><code>gem 'kaminari'</code><p>ページネーション機能を追加</p></div>
+                <div class="command-card" id="cmd-gem-ransack"><h3>Ransack - 検索</h3><code>gem 'ransack'</code><p>高度な検索機能を提供</p></div>
+                <div class="command-card" id="cmd-gem-sidekiq"><h3>Sidekiq - バックグラウンドジョブ</h3><code>gem 'sidekiq'</code><p>非同期ジョブ処理</p></div>
+                <div class="command-card" id="cmd-gem-rspec-rails"><h3>RSpec - テスト</h3><code>gem 'rspec-rails'</code><p>BDDテストフレームワーク</p></div>
+                <div class="command-card" id="cmd-gem-factory-bot-rails"><h3>FactoryBot - テストデータ</h3><code>gem 'factory_bot_rails'</code><p>テスト用データの生成</p></div>
+                <div class="command-card" id="cmd-gem-faker"><h3>Faker - ダミーデータ</h3><code>gem 'faker'</code><p>リアルなダミーデータを生成</p></div>
+                <div class="command-card" id="cmd-gem-pry-rails"><h3>Pry - デバッグ</h3><code>gem 'pry-rails'</code><p>強力なデバッグツール</p></div>
+                <div class="command-card" id="cmd-gem-rubocop"><h3>Rubocop - コード検査</h3><code>gem 'rubocop'</code><p>コードスタイルチェッカー</p></div>
+                <div class="command-card" id="cmd-gem-slim-rails"><h3>Slim - テンプレート</h3><code>gem 'slim-rails'</code><p>軽量テンプレート言語</p></div>
+                <div class="command-card" id="cmd-gem-bootstrap"><h3>Bootstrap - UI</h3><code>gem 'bootstrap'</code><p>レスポンシブUIフレームワーク</p></div>
+                <div class="command-card" id="cmd-gem-draper"><h3>Draper - デコレーター</h3><code>gem 'draper'</code><p>ビューロジックの分離</p></div>
+                <div class="command-card" id="cmd-gem-activeadmin"><h3>ActiveAdmin - 管理画面</h3><code>gem 'activeadmin'</code><p>管理画面を簡単に作成</p></div>
+                <div class="command-card" id="cmd-gem-paperclip"><h3>Paperclip - ファイル管理</h3><code>gem 'paperclip'</code><p>ファイル添付機能</p></div>
+                <div class="command-card" id="cmd-gem-grape"><h3>Grape - API</h3><code>gem 'grape'</code><p>RESTful API構築フレームワーク</p></div>
+                <div class="command-card" id="cmd-gem-jwt"><h3>JWT - トークン認証</h3><code>gem 'jwt'</code><p>JSON Web Token認証</p></div>
+                <div class="command-card" id="cmd-gem-redis"><h3>Redis - キャッシュ</h3><code>gem 'redis'</code><p>高速キャッシュストア</p></div>
+                <div class="command-card" id="cmd-gem-whenever"><h3>Whenever - Cron管理</h3><code>gem 'whenever'</code><p>Cronジョブの管理</p></div>
+                <div class="command-card" id="cmd-gem-letter-opener"><h3>Letter Opener - メール確認</h3><code>gem 'letter_opener'</code><p>開発環境でメールを確認</p></div>
+                <div class="command-card" id="cmd-gem-dotenv-rails"><h3>Dotenv - 環境変数</h3><code>gem 'dotenv-rails'</code><p>環境変数の管理</p></div>
+                <div class="command-card" id="cmd-gem-i18n"><h3>I18n - 国際化</h3><code>gem 'rails-i18n'</code><p>多言語対応機能</p></div>
+            </div>
+        </section>
+        <section id="mvc" class="category">
+            <h2 style="border-bottom: 2px solid #ddd; padding-bottom: 10px; margin-top: 40px;">🏗️ MVC パターンリファレンス</h2>
+            <div class="commands-grid">
+                <div class="command-card" id="cmd-mvc-model-base"><h3>Model - Active Record基本</h3><code>class User < ApplicationRecord</code><p>データベースとの対話を担当するモデル層</p></div>
+                <div class="command-card" id="cmd-mvc-model-validation"><h3>Model - バリデーション</h3><code>validates :email, presence: true</code><p>データの整合性を保証する検証ルール</p></div>
+                <div class="command-card" id="cmd-mvc-model-association"><h3>Model - アソシエーション</h3><code>has_many :posts</code><p>モデル間の関連付けを定義</p></div>
+                <div class="command-card" id="cmd-mvc-model-scope"><h3>Model - スコープ</h3><code>scope :active, -> { where(active: true) }</code><p>よく使うクエリを再利用可能に</p></div>
+                <div class="command-card" id="cmd-mvc-model-callback"><h3>Model - コールバック</h3><code>before_save :normalize_email</code><p>特定のタイミングで処理を実行</p></div>
+                <div class="command-card" id="cmd-mvc-controller-base"><h3>Controller - 基本構造</h3><code>class UsersController < ApplicationController</code><p>リクエストを処理しレスポンスを返す</p></div>
+                <div class="command-card" id="cmd-mvc-controller-actions"><h3>Controller - RESTfulアクション</h3><code>def index; @users = User.all; end</code><p>7つの基本アクション(index,show,new,create,edit,update,destroy)</p></div>
+                <div class="command-card" id="cmd-mvc-controller-strong-params"><h3>Controller - Strong Parameters</h3><code>params.require(:user).permit(:name, :email)</code><p>セキュアなパラメータ処理</p></div>
+                <div class="command-card" id="cmd-mvc-controller-filter"><h3>Controller - フィルター</h3><code>before_action :authenticate_user!</code><p>アクション実行前後の処理</p></div>
+                <div class="command-card" id="cmd-mvc-view-erb"><h3>View - ERBテンプレート</h3><code><%= @user.name %></code><p>動的なHTMLを生成するテンプレート</p></div>
+                <div class="command-card" id="cmd-mvc-view-partial"><h3>View - パーシャル</h3><code><%= render 'shared/header' %></code><p>ビューの再利用可能な部品</p></div>
+                <div class="command-card" id="cmd-mvc-view-helper"><h3>View - ヘルパーメソッド</h3><code><%= link_to 'Home', root_path %></code><p>ビューで使える便利なメソッド</p></div>
+                <div class="command-card" id="cmd-mvc-view-form"><h3>View - フォームヘルパー</h3><code><%= form_with model: @user %></code><p>フォーム作成を簡単に</p></div>
+                <div class="command-card" id="cmd-mvc-routes-resources"><h3>Routes - リソースルート</h3><code>resources :users</code><p>RESTfulなルーティングを一括定義</p></div>
+                <div class="command-card" id="cmd-mvc-routes-nested"><h3>Routes - ネストしたルート</h3><code>resources :users do\n  resources :posts\nend</code><p>階層的なURL構造を定義</p></div>
+                <div class="command-card" id="cmd-mvc-migration-create"><h3>Migration - テーブル作成</h3><code>create_table :users do |t|</code><p>データベーステーブルの作成</p></div>
+                <div class="command-card" id="cmd-mvc-migration-add-column"><h3>Migration - カラム追加</h3><code>add_column :users, :age, :integer</code><p>既存テーブルにカラムを追加</p></div>
+                <div class="command-card" id="cmd-mvc-migration-add-index"><h3>Migration - インデックス追加</h3><code>add_index :users, :email</code><p>検索パフォーマンスを向上</p></div>
+                <div class="command-card" id="cmd-mvc-ar-query"><h3>Active Record - クエリメソッド</h3><code>User.where(active: true).order(:name)</code><p>データベースクエリの構築</p></div>
+                <div class="command-card" id="cmd-mvc-ar-includes"><h3>Active Record - N+1問題対策</h3><code>User.includes(:posts)</code><p>関連データを効率的に取得</p></div>
+            </div>
+        </section>
+        <section id="debug" class="category">
+            <h2 style="border-bottom: 2px solid #ddd; padding-bottom: 10px; margin-top: 40px;">🐛 デバッグリファレンス</h2>
+            <div class="commands-grid">
+                <div class="command-card" id="cmd-binding-pry"><h3>binding.pry挿入</h3><code>binding.pry</code><p>コードの実行を一時停止してデバッグ</p></div>
+                <div class="command-card" id="cmd-byebug"><h3>byebugデバッガー</h3><code>byebug</code><p>ブレークポイントを設定</p></div>
+                <div class="command-card" id="cmd-rails-logger-debug"><h3>Rails.logger出力</h3><code>Rails.logger.debug "変数: #{@variable}"</code><p>ログファイルにデバッグ情報を出力</p></div>
+                <div class="command-card" id="cmd-user-to-sql"><h3>コンソールでSQL確認</h3><code>User.all.to_sql</code><p>発行されるSQLクエリを確認</p></div>
+                <div class="command-card" id="cmd-gem-better-errors"><h3>better_errorsエラー画面</h3><code>gem 'better_errors'</code><p>エラー画面を見やすく改善</p></div>
+                <div class="command-card" id="cmd-rails-c-sandbox"><h3>rails consoleでデバッグ</h3><code>rails c --sandbox</code><p>サンドボックスモードで安全にテスト</p></div>
+                <div class="command-card" id="cmd-config-log-level"><h3>ログレベル変更</h3><code>config.log_level = :debug</code><p>詳細なログ情報を出力</p></div>
+                <div class="command-card" id="cmd-gem-bullet"><h3>Bullet - N+1検出</h3><code>gem 'bullet'</code><p>N+1問題を自動検出</p></div>
+                <div class="command-card" id="cmd-gem-rack-mini-profiler"><h3>rack-mini-profiler</h3><code>gem 'rack-mini-profiler'</code><p>ページ読み込み時間を分析</p></div>
+                <div class="command-card" id="cmd-chrome-logger"><h3>chrome_logger</h3><code>ChromeLogger.debug(variable)</code><p>ブラウザコンソールにログ出力</p></div>
+                <div class="command-card" id="cmd-puts-caller"><h3>エラーバックトレース</h3><code>puts caller</code><p>メソッド呼び出し履歴を表示</p></div>
+                <div class="command-card" id="cmd-pp-user"><h3>オブジェクト詳細表示</h3><code>pp @user</code><p>オブジェクトを見やすく表示</p></div>
+            </div>
+        </section>
+        <section id="database" class="category">
+            <h2 style="border-bottom: 2px solid #ddd; padding-bottom: 10px; margin-top: 40px;">🗄️ データベースリファレンス</h2>
+            <div class="commands-grid">
+                <div class="command-card" id="cmd-db-version"><h3>DB接続確認</h3><code>rails db:version</code><p>現在のDBバージョンを確認</p></div>
+                <div class="command-card" id="cmd-db-reset"><h3>DBリセット</h3><code>rails db:reset</code><p>DBを削除して再作成</p></div>
+                <div class="command-card" id="cmd-db-schema-load"><h3>DBスキーマ読み込み</h3><code>rails db:schema:load</code><p>schema.rbからDBを構築</p></div>
+                <div class="command-card" id="cmd-db-seed-replant"><h3>DBシード実行</h3><code>rails db:seed:replant</code><p>データを削除してシード再実行</p></div>
+                <div class="command-card" id="cmd-db-migrate-up"><h3>特定マイグレーション実行</h3><code>rails db:migrate:up VERSION=20231201</code><p>特定のマイグレーションを実行</p></div>
+                <div class="command-card" id="cmd-db-migrate-status"><h3>マイグレーション状態確認</h3><code>rails db:migrate:status</code><p>各マイグレーションの適用状態</p></div>
+                <div class="command-card" id="cmd-dbconsole"><h3>DBコンソール起動</h3><code>rails dbconsole</code><p>データベースのCLIに接続</p></div>
+                <div class="command-card" id="cmd-db-schema-dump"><h3>DBダンプ作成</h3><code>rails db:schema:dump</code><p>現在のDBスキーマを出力</p></div>
+                <div class="command-card" id="cmd-psql"><h3>PostgreSQL接続</h3><code>psql -d database_name</code><p>PostgreSQLコンソールに接続</p></div>
+                <div class="command-card" id="cmd-mysql"><h3>MySQL接続</h3><code>mysql -u root -p database_name</code><p>MySQLコンソールに接続</p></div>
+                <div class="command-card" id="cmd-sqlite3"><h3>SQLite3接続</h3><code>sqlite3 db/development.sqlite3</code><p>SQLite3データベースに接続</p></div>
+                <div class="command-card" id="cmd-ar-execute"><h3>ActiveRecord SQL実行</h3><code>ActiveRecord::Base.connection.execute("SQL")</code><p>生SQLを直接実行</p></div>
+            </div>
+        </section>
+        <section id="testing" class="category">
+            <h2 style="border-bottom: 2px solid #ddd; padding-bottom: 10px; margin-top: 40px;">🧪 テストリファレンス</h2>
+            <div class="commands-grid">
+                <div class="command-card" id="cmd-test-all"><h3>全テスト実行</h3><code>rails test</code><p>すべてのテストを実行</p></div>
+                <div class="command-card" id="cmd-test-file"><h3>特定テスト実行</h3><code>rails test test/models/user_test.rb</code><p>特定のテストファイルを実行</p></div>
+                <div class="command-card" id="cmd-rspec"><h3>RSpec実行</h3><code>bundle exec rspec</code><p>RSpecテストを実行</p></div>
+                <div class="command-card" id="cmd-rspec-line"><h3>特定スペック実行</h3><code>rspec spec/models/user_spec.rb:10</code><p>特定の行のテストを実行</p></div>
+                <div class="command-card" id="cmd-db-test-prepare"><h3>テストDB準備</h3><code>rails db:test:prepare</code><p>テスト用DBを準備</p></div>
+                <div class="command-card" id="cmd-coverage"><h3>カバレッジ確認</h3><code>open coverage/index.html</code><p>テストカバレッジレポートを確認</p></div>
+                <div class="command-card" id="cmd-factory-bot-create"><h3>Factory作成</h3><code>FactoryBot.create(:user)</code><p>テストデータを作成</p></div>
+                <div class="command-card" id="cmd-test-system"><h3>システムテスト実行</h3><code>rails test:system</code><p>ブラウザを使った統合テスト</p></div>
+                <div class="command-card" id="cmd-test-parallel"><h3>並列テスト実行</h3><code>rails test -j 4</code><p>4つのプロセスで並列実行</p></div>
+                <div class="command-card" id="cmd-guard"><h3>Guard自動テスト</h3><code>bundle exec guard</code><p>ファイル変更を監視して自動テスト</p></div>
+                <div class="command-card" id="cmd-rspec-only-failures"><h3>テストのみ実行（失敗のみ）</h3><code>rspec --only-failures</code><p>前回失敗したテストのみ実行</p></div>
+                <div class="command-card" id="cmd-rspec-seed"><h3>テストのシード値固定</h3><code>rspec --seed 12345</code><p>ランダムテストの順序を固定</p></div>
+            </div>
+        </section>
+        <section id="performance" class="category">
+            <h2 style="border-bottom: 2px solid #ddd; padding-bottom: 10px; margin-top: 40px;">⚡ パフォーマンスリファレンス</h2>
+            <div class="commands-grid">
+                <div class="command-card" id="cmd-perf-includes"><h3>クエリ最適化 - includes</h3><code>User.includes(:posts, :comments)</code><p>N+1問題を防ぐEager Loading</p></div>
+                <div class="command-card" id="cmd-perf-select"><h3>クエリ最適化 - select</h3><code>User.select(:id, :name)</code><p>必要なカラムのみ取得</p></div>
+                <div class="command-card" id="cmd-perf-find-each"><h3>バッチ処理</h3><code>User.find_each(batch_size: 1000)</code><p>大量データを分割処理</p></div>
+                <div class="command-card" id="cmd-perf-caches-page"><h3>キャッシュ - ページ</h3><code>caches_page :index</code><p>ページ全体をキャッシュ</p></div>
+                <div class="command-card" id="cmd-perf-caches-fragment"><h3>キャッシュ - フラグメント</h3><code><% cache @user do %></code><p>ビューの一部をキャッシュ</p></div>
+                <div class="command-card" id="cmd-perf-cache-russian-doll"><h3>キャッシュ - ロシアンドール</h3><code>cache [@user, @post]</code><p>ネストしたキャッシュ戦略</p></div>
+                <div class="command-card" id="cmd-perf-cache-redis"><h3>Redis キャッシュ</h3><code>Rails.cache.fetch("key") { ... }</code><p>Redisを使った高速キャッシュ</p></div>
+                <div class="command-card" id="cmd-perf-assets-compress"><h3>アセット圧縮</h3><code>config.assets.js_compressor = :uglifier</code><p>JavaScriptファイルを圧縮</p></div>
+                <div class="command-card" id="cmd-perf-image-lazy-load"><h3>画像最適化</h3><code>image_tag "photo.jpg", loading: "lazy"</code><p>画像の遅延読み込み</p></div>
+                <div class="command-card" id="cmd-perf-db-index"><h3>データベースインデックス</h3><code>add_index :users, [:email, :created_at]</code><p>複合インデックスで検索高速化</p></div>
+                <div class="command-card" id="cmd-perf-counter-cache"><h3>カウンターキャッシュ</h3><code>counter_cache: true</code><p>関連レコード数をキャッシュ</p></div>
+                <div class="command-card" id="cmd-perf-webpacker-compile"><h3>Webpacker最適化</h3><code>rails webpacker:compile</code><p>本番用にアセットを最適化</p></div>
+                <div class="command-card" id="cmd-perf-turbo"><h3>Turbo使用</h3><code>data: { turbo: true }</code><p>SPAのような高速画面遷移</p></div>
+                <div class="command-card" id="cmd-perf-cdn"><h3>CDN設定</h3><code>config.action_controller.asset_host</code><p>静的ファイルをCDNから配信</p></div>
+                <div class="command-card" id="cmd-perf-ruby-prof"><h3>プロファイリング</h3><code>ruby-prof</code><p>コードの実行時間を詳細分析</p></div>
+                <div class="command-card" id="cmd-perf-memory-profiler"><h3>メモリ使用量確認</h3><code>memory_profiler</code><p>メモリリークを検出</p></div>
+            </div>
+        </section>
+        <section id="errors" class="category">
+            <h2 style="border-bottom: 2px solid #ddd; padding-bottom: 10px; margin-top: 40px;">🚨 エラーパターンリファレンス</h2>
+            <div class="commands-grid">
+                <div class="command-card" id="cmd-err-nomethod"><h3>NoMethodError</h3><code>undefined method 'name' for nil:NilClass</code><p>nilオブジェクトにメソッドを呼び出し。&.演算子やif文で対処</p></div>
+                <div class="command-card" id="cmd-err-nameerror"><h3>NameError</h3><code>uninitialized constant User</code><p>クラスが定義されていない。ファイル名とクラス名の確認</p></div>
+                <div class="command-card" id="cmd-err-syntaxerror"><h3>SyntaxError</h3><code>unexpected end-of-input</code><p>endの不足やカッコの不一致。インデントを確認</p></div>
+                <div class="command-card" id="cmd-err-recordnotfound"><h3>ActiveRecord::RecordNotFound</h3><code>Couldn't find User with 'id'=1</code><p>存在しないレコード。find_byやrescueで対処</p></div>
+                <div class="command-card" id="cmd-err-recordinvalid"><h3>ActiveRecord::RecordInvalid</h3><code>Validation failed: Email can't be blank</code><p>バリデーションエラー。save!の代わりにsaveを使用</p></div>
+                <div class="command-card" id="cmd-err-parammissing"><h3>ActionController::ParameterMissing</h3><code>param is missing or empty: user</code><p>必須パラメータ不足。Strong Parametersを確認</p></div>
+                <div class="command-card" id="cmd-err-missingtemplate"><h3>ActionView::MissingTemplate</h3><code>Missing template users/index</code><p>ビューファイルが存在しない。ファイルパスを確認</p></div>
+                <div class="command-card" id="cmd-err-loaderror"><h3>LoadError</h3><code>cannot load such file -- bcrypt</code><p>Gemが見つからない。bundle installを実行</p></div>
+                <div class="command-card" id="cmd-err-pg-connectionbad"><h3>PG::ConnectionBad</h3><code>could not connect to server</code><p>PostgreSQLが起動していない。brew services start postgresql</p></div>
+                <div class="command-card" id="cmd-err-mysql-connection"><h3>Mysql2::Error::ConnectionError</h3><code>Can't connect to MySQL server</code><p>MySQLが起動していない。sudo service mysql start</p></div>
+                <div class="command-card" id="cmd-err-pendingmigration"><h3>ActiveRecord::PendingMigrationError</h3><code>Migrations are pending</code><p>未実行のマイグレーション。rails db:migrateを実行</p></div>
+                <div class="command-card" id="cmd-err-statementinvalid"><h3>ActiveRecord::StatementInvalid</h3><code>SQLite3::SQLException: no such column</code><p>カラムが存在しない。マイグレーションファイルを確認</p></div>
+                <div class="command-card" id="cmd-err-invalidauthenticitytoken"><h3>ActionController::InvalidAuthenticityToken</h3><code>Can't verify CSRF token</code><p>CSRFトークンエラー。フォームにcsrf_meta_tagsを追加</p></div>
+                <div class="command-card" id="cmd-err-readtimeout"><h3>Net::ReadTimeout</h3><code>execution expired</code><p>タイムアウト。タイムアウト時間を延長またはリトライ処理</p></div>
+                <div class="command-card" id="cmd-err-duplicateentry"><h3>ActiveRecord::DuplicateEntry</h3><code>Duplicate entry for key 'index_users_on_email'</code><p>一意制約違反。データの重複を確認</p></div>
+                <div class="command-card" id="cmd-err-argumenterror"><h3>ArgumentError</h3><code>wrong number of arguments (given 2, expected 1)</code><p>引数の数が違う。メソッド定義を確認</p></div>
+                <div class="command-card" id="cmd-err-typeerror"><h3>TypeError</h3><code>no implicit conversion of Symbol into Integer</code><p>型の不一致。配列とハッシュの混同を確認</p></div>
+                <div class="command-card" id="cmd-err-gemnotfound"><h3>Bundler::GemNotFound</h3><code>Could not find gem 'rails'</code><p>Gemが見つからない。bundle installを実行</p></div>
+                <div class="command-card" id="cmd-err-webpacker-manifest"><h3>Webpacker::Manifest::MissingEntryError</h3><code>Can't find application.js in manifest.json</code><p>Webpackerコンパイルエラー。rails webpacker:compileを実行</p></div>
+                <div class="command-card" id="cmd-err-activestorage-filenotfound"><h3>ActiveStorage::FileNotFoundError</h3><code>Could not find file</code><p>アップロードファイルが見つからない。ストレージを確認</p></div>
+                <div class="command-card" id="cmd-err-redis-connect"><h3>Redis::CannotConnectError</h3><code>Error connecting to Redis</code><p>Redisが起動していない。redis-serverを起動</p></div>
+                <div class="command-card" id="cmd-err-addrinuse"><h3>Errno::EADDRINUSE</h3><code>Address already in use - bind(2) port 3000</code><p>ポートが使用中。lsof -i:3000でプロセスを確認してkill</p></div>
+                <div class="command-card" id="cmd-err-activejob-deserialize"><h3>ActiveJob::DeserializationError</h3><code>Error while trying to deserialize arguments</code><p>ジョブの引数エラー。GlobalIDを使用またはIDを渡す</p></div>
+                <div class="command-card" id="cmd-err-standarderror"><h3>StandardError - カスタムエラー処理</h3><code>rescue StandardError => e</code><p>汎用的なエラーキャッチ。ログ出力して適切に処理</p></div>
+            </div>
+        </section>
+        <section id="http" class="category">
+            <h2 style="border-bottom: 2px solid #ddd; padding-bottom: 10px; margin-top: 40px;">🌐 HTTPリファレンス</h2>
+            <div class="commands-grid">
+                <div class="command-card" id="cmd-http-get"><h3>GET - データ取得</h3><code>curl -X GET https://api.example.com/users</code><p>サーバーからデータを取得。リソースの読み取り専用</p></div>
+                <div class="command-card" id="cmd-http-post"><h3>POST - データ作成</h3><code>curl -X POST -d '{"name":"John"}' https://api.example.com/users</code><p>新しいリソースを作成。サーバーにデータを送信</p></div>
+                <div class="command-card" id="cmd-http-put"><h3>PUT - データ更新（全体）</h3><code>curl -X PUT -d '{"name":"Jane"}' https://api.example.com/users/1</code><p>既存リソース全体を置き換え。完全な更新</p></div>
+                <div class="command-card" id="cmd-http-patch"><h3>PATCH - データ更新（部分）</h3><code>curl -X PATCH -d '{"email":"new@example.com"}' https://api.example.com/users/1</code><p>既存リソースの一部を更新。部分的な変更</p></div>
+                <div class="command-card" id="cmd-http-delete"><h3>DELETE - データ削除</h3><code>curl -X DELETE https://api.example.com/users/1</code><p>指定したリソースを削除。サーバーから完全に削除</p></div>
+                <div class="command-card" id="cmd-http-head"><h3>HEAD - ヘッダー取得</h3><code>curl -I https://api.example.com/users</code><p>レスポンスヘッダーのみ取得。ボディなし</p></div>
+                <div class="command-card" id="cmd-http-options"><h3>OPTIONS - 許可メソッド確認</h3><code>curl -X OPTIONS https://api.example.com/users</code><p>サーバーがサポートするHTTPメソッドを確認</p></div>
+                <div class="command-card" id="cmd-curl-get"><h3>curl - 基本的なGETリクエスト</h3><code>curl https://api.example.com/data</code><p>最もシンプルなHTTPリクエスト実行</p></div>
+                <div class="command-card" id="cmd-curl-header"><h3>curl - ヘッダー付きリクエスト</h3><code>curl -H "Authorization: Bearer token" https://api.example.com</code><p>認証トークンなどのヘッダーを追加</p></div>
+                <div class="command-card" id="cmd-curl-json"><h3>curl - JSONデータ送信</h3><code>curl -H "Content-Type: application/json" -d '{"key":"value"}' https://api.example.com</code><p>JSON形式でデータを送信</p></div>
+                <div class="command-card" id="cmd-curl-form"><h3>curl - フォームデータ送信</h3><code>curl -X POST -F "name=value" -F "file=@path/to/file" https://api.example.com</code><p>フォーム形式でデータとファイルを送信</p></div>
+                <div class="command-card" id="cmd-curl-basic-auth"><h3>curl - Basic認証</h3><code>curl -u username:password https://api.example.com</code><p>Basic認証でアクセス</p></div>
+                <div class="command-card" id="cmd-curl-cookie"><h3>curl - クッキー送信</h3><code>curl -b "session=abc123" https://api.example.com</code><p>クッキーを含めてリクエスト</p></div>
+                <div class="command-card" id="cmd-curl-cookie-jar"><h3>curl - クッキー保存</h3><code>curl -c cookies.txt https://api.example.com/login</code><p>レスポンスのクッキーをファイルに保存</p></div>
+                <div class="command-card" id="cmd-curl-timeout"><h3>curl - タイムアウト設定</h3><code>curl --connect-timeout 10 --max-time 30 https://api.example.com</code><p>接続と全体のタイムアウトを設定</p></div>
+                <div class="command-card" id="cmd-curl-redirect"><h3>curl - リダイレクト追跡</h3><code>curl -L https://api.example.com</code><p>リダイレクトを自動的に追跡</p></div>
+                <div class="command-card" id="cmd-curl-proxy"><h3>curl - プロキシ経由</h3><code>curl -x http://proxy:8080 https://api.example.com</code><p>プロキシサーバー経由でアクセス</p></div>
+                <div class="command-card" id="cmd-curl-insecure"><h3>curl - SSL証明書検証スキップ</h3><code>curl -k https://api.example.com</code><p>開発環境でSSL証明書の検証をスキップ</p></div>
+                <div class="command-card" id="cmd-curl-jq"><h3>curl - レスポンスを整形</h3><code>curl https://api.example.com/data | jq</code><p>JSONレスポンスを見やすく整形</p></div>
+                <div class="command-card" id="cmd-curl-download"><h3>curl - ファイルダウンロード</h3><code>curl -O https://example.com/file.pdf</code><p>ファイルをダウンロードして保存</p></div>
+                <div class="command-card" id="cmd-curl-verbose"><h3>curl - 詳細情報表示</h3><code>curl -v https://api.example.com</code><p>リクエスト/レスポンスの詳細を表示</p></div>
+                <div class="command-card" id="cmd-curl-silent"><h3>curl - 静かモード</h3><code>curl -s https://api.example.com</code><p>進捗バーなどを非表示にして実行</p></div>
+                <div class="command-card" id="cmd-httpie-get"><h3>HTTPie - GET</h3><code>http GET api.example.com/users</code><p>HTTPieを使った見やすいGETリクエスト</p></div>
+                <div class="command-card" id="cmd-httpie-post"><h3>HTTPie - POST</h3><code>http POST api.example.com/users name="John" age=30</code><p>HTTPieでJSON形式のPOSTリクエスト</p></div>
+                <div class="command-card" id="cmd-wget-get"><h3>wget - ファイル取得</h3><code>wget https://example.com/file.zip</code><p>ファイルをダウンロード</p></div>
+                <div class="command-card" id="cmd-wget-recursive"><h3>wget - 再帰的ダウンロード</h3><code>wget -r https://example.com/docs/</code><p>ディレクトリ全体を再帰的にダウンロード</p></div>
+                <div class="command-card" id="cmd-rails-net-http"><h3>Rails - HTTPリクエスト（Net::HTTP）</h3><code>Net::HTTP.get(URI('https://api.example.com/data'))</code><p>RubyのNet::HTTPライブラリでGETリクエスト</p></div>
+                <div class="command-card" id="cmd-rails-httparty"><h3>Rails - HTTParty gem</h3><code>HTTParty.get('https://api.example.com/users')</code><p>HTTParty gemを使った簡単なHTTPリクエスト</p></div>
+                <div class="command-card" id="cmd-rails-faraday"><h3>Rails - Faraday gem</h3><code>Faraday.get('https://api.example.com/data')</code><p>Faraday gemでHTTPリクエスト</p></div>
+                <div class="command-card" id="cmd-rails-rest-client"><h3>Rails - RestClient gem</h3><code>RestClient.get 'https://api.example.com/users'</code><p>RestClient gemでシンプルなAPI呼び出し</p></div>
+                <div class="command-card" id="cmd-rails-api-auth"><h3>Rails - API認証付きリクエスト</h3><code>HTTParty.get(url, headers: { 'Authorization' => "Bearer #{token}" })</code><p>認証トークン付きのAPIリクエスト</p></div>
+                <div class="command-card" id="cmd-status-200"><h3>ステータスコード - 200 OK</h3><code>HTTP/1.1 200 OK</code><p>リクエスト成功。正常にデータを返す</p></div>
+                <div class="command-card" id="cmd-status-201"><h3>ステータスコード - 201 Created</h3><code>HTTP/1.1 201 Created</code><p>新しいリソースの作成成功</p></div>
+                <div class="command-card" id="cmd-status-204"><h3>ステータスコード - 204 No Content</h3><code>HTTP/1.1 204 No Content</code><p>成功したが返すコンテンツなし</p></div>
+                <div class="command-card" id="cmd-status-400"><h3>ステータスコード - 400 Bad Request</h3><code>HTTP/1.1 400 Bad Request</code><p>不正なリクエスト。パラメータエラー</p></div>
+                <div class="command-card" id="cmd-status-401"><h3>ステータスコード - 401 Unauthorized</h3><code>HTTP/1.1 401 Unauthorized</code><p>認証が必要。認証情報なしまたは無効</p></div>
+                <div class="command-card" id="cmd-status-403"><h3>ステータスコード - 403 Forbidden</h3><code>HTTP/1.1 403 Forbidden</code><p>アクセス禁止。権限不足</p></div>
+                <div class="command-card" id="cmd-status-404"><h3>ステータスコード - 404 Not Found</h3><code>HTTP/1.1 404 Not Found</code><p>リソースが見つからない</p></div>
+                <div class="command-card" id="cmd-status-422"><h3>ステータスコード - 422 Unprocessable Entity</h3><code>HTTP/1.1 422 Unprocessable Entity</code><p>検証エラー。データは正しいが処理できない</p></div>
+                <div class="command-card" id="cmd-status-500"><h3>ステータスコード - 500 Internal Server Error</h3><code>HTTP/1.1 500 Internal Server Error</code><p>サーバー内部エラー</p></div>
+                <div class="command-card" id="cmd-status-502"><h3>ステータスコード - 502 Bad Gateway</h3><code>HTTP/1.1 502 Bad Gateway</code><p>ゲートウェイまたはプロキシのエラー</p></div>
+                <div class="command-card" id="cmd-status-503"><h3>ステータスコード - 503 Service Unavailable</h3><code>HTTP/1.1 503 Service Unavailable</code><p>サービス利用不可。メンテナンス中など</p></div>
             </div>
         </section>
     </main>

--- a/styles.css
+++ b/styles.css
@@ -236,3 +236,76 @@ h1 {
 ::-webkit-scrollbar-thumb:hover {
     background: #5a3785;
 }
+
+/* --- Tutorial Card Styles --- */
+.tutorial-card {
+    background: #fdfdff;
+    padding: 25px 30px;
+    border-radius: 15px;
+    box-shadow: 0 5px 20px rgba(0, 0, 0, 0.08);
+    margin-bottom: 25px;
+    border-left: 5px solid #667eea;
+}
+
+.tutorial-card h3 {
+    color: #667eea;
+    font-size: 22px;
+    margin-bottom: 20px;
+    padding-bottom: 10px;
+    border-bottom: 2px solid #f0f0f0;
+}
+
+.tutorial-card p, .tutorial-card li {
+    font-size: 15px;
+    line-height: 1.8;
+    color: #444;
+}
+
+.tutorial-card ol {
+    padding-left: 20px;
+    margin-top: 15px;
+    margin-bottom: 15px;
+}
+
+.tutorial-card ol li {
+    margin-bottom: 12px;
+}
+
+.tutorial-card code {
+    background: #e9eaf7;
+    color: #667eea;
+    padding: 3px 6px;
+    border-radius: 5px;
+    font-family: 'Courier New', monospace;
+    font-size: 14px;
+}
+
+.tutorial-card a code {
+    transition: all 0.3s;
+}
+
+.tutorial-card a:hover code {
+    background: #667eea;
+    color: white;
+}
+
+.tutorial-card .prerequisites {
+    background: #f7f7f9;
+    border: 1px solid #e0e0e0;
+    padding: 15px;
+    border-radius: 10px;
+    margin: 20px 0;
+}
+
+.tutorial-card .prerequisites h4 {
+    margin-top: 0;
+    margin-bottom: 10px;
+    color: #764ba2;
+}
+
+.tutorial-card hr {
+    border: 0;
+    height: 1px;
+    background-color: #e8e8e8;
+    margin: 25px 0;
+}


### PR DESCRIPTION
Refactors the cheat sheet to a hybrid model based on user feedback. The new structure features tutorial sections for common workflows at the top of the page, followed by the original, comprehensive command reference sections grouped by technology.

- Adds three new tutorial sections: Environment Setup, New Feature Workflow, and Debugging Workflow.
- Implements a linking system where commands in the tutorials jump to the detailed command cards in the reference sections below, ensuring maintainability by avoiding code duplication.
- Adds unique IDs to all 357 command cards to enable this linking.
- Adds new CSS to `styles.css` for a clean and readable UI for the tutorial sections, distinguishing them from the reference cards.
- The sidebar is updated to provide easy navigation to both the new tutorials and the original reference sections.